### PR TITLE
Adding support for multiple file extensions

### DIFF
--- a/doxia-core/src/main/java/org/apache/maven/doxia/parser/module/AbstractParserModule.java
+++ b/doxia-core/src/main/java/org/apache/maven/doxia/parser/module/AbstractParserModule.java
@@ -27,13 +27,19 @@ package org.apache.maven.doxia.parser.module;
 public abstract class AbstractParserModule
     implements ParserModule
 {
-    /** The source directory. */
+    /**
+     * The source directory.
+     */
     private final String sourceDirectory;
 
-    /** The default file extension. */
-    private final String extension;
+    /**
+     * The default file extension.
+     */
+    private final String[] extension;
 
-    /** The default file extension. */
+    /**
+     * The default file extension.
+     */
     private final String parserId;
 
     /**
@@ -55,18 +61,18 @@ public abstract class AbstractParserModule
     /**
      * Constructor with same value for parser id and source directory.
      */
-    public AbstractParserModule( String parserId, String extension )
+    public AbstractParserModule( String parserId, String... extension )
     {
         this( parserId, extension, parserId );
     }
 
     /**
      * @param sourceDirectory not null
-     * @param extension not null
-     * @param parserId not null
+     * @param extension       not null
+     * @param parserId        not null
      * @since 1.1.1
      */
-    protected AbstractParserModule( String sourceDirectory, String extension, String parserId )
+    protected AbstractParserModule( String sourceDirectory, String[] extension, String parserId )
     {
         super();
         this.sourceDirectory = sourceDirectory;
@@ -74,19 +80,25 @@ public abstract class AbstractParserModule
         this.parserId = parserId;
     }
 
-    /** {@inheritDoc} */
+    /**
+     * {@inheritDoc}
+     */
     public String getSourceDirectory()
     {
         return sourceDirectory;
     }
 
-    /** {@inheritDoc} */
-    public String getExtension()
+    /**
+     * {@inheritDoc}
+     */
+    public String[] getExtension()
     {
         return extension;
     }
 
-    /** {@inheritDoc} */
+    /**
+     * {@inheritDoc}
+     */
     public String getParserId()
     {
         return parserId;

--- a/doxia-core/src/main/java/org/apache/maven/doxia/parser/module/ParserModule.java
+++ b/doxia-core/src/main/java/org/apache/maven/doxia/parser/module/ParserModule.java
@@ -39,7 +39,7 @@ public interface ParserModule
      *
      * @return The default file extension.
      */
-    String getExtension();
+    String[] getExtension();
 
     /**
      * Returns the parser id for a given module.

--- a/pom.xml
+++ b/pom.xml
@@ -395,6 +395,7 @@ under the License.
             <exclude>src/test/site/**/*.confluence</exclude>
             <exclude>src/test/resources/**/*.twiki</exclude>
             <exclude>src/test/resources/**/*.md</exclude>
+            <exclude>*.state</exclude>
           </excludes>            
         </configuration>
         <executions>


### PR DESCRIPTION
Following this thread asciidoctor/asciidoctor-maven-plugin#125 Here's a pull request that will allow parsers to specify more than one file extension. Also note that changes need to be made also in `doxia-sitetools` (pull request also submitted). I tried to use the maven committer environment as specified here http://maven.apache.org/developers/committer-environment.html but the code got formatted badly. Please let me know what you think.
