### PR TITLE
Propagate macro related exceptions to caller in xhtml parser

### DIFF
--- a/doxia-modules/doxia-module-xhtml/src/main/java/org/apache/maven/doxia/module/xhtml/XhtmlParser.java
+++ b/doxia-modules/doxia-module-xhtml/src/main/java/org/apache/maven/doxia/module/xhtml/XhtmlParser.java
@@ -269,11 +269,11 @@ public class XhtmlParser
         }
         catch ( MacroExecutionException e )
         {
-            throw new XmlPullParserException( "Unable to execute macro in the document: " + macroName );
+            throw new XmlPullParserException( "Unable to execute macro in the document: " + macroName , e);
         }
         catch ( MacroNotFoundException me )
         {
-            throw new XmlPullParserException( "Macro not found: " + macroName );
+            throw new XmlPullParserException( "Macro not found: " + macroName, me);
         }
     }
 

--- a/doxia-modules/doxia-module-xhtml/src/main/java/org/apache/maven/doxia/module/xhtml/XhtmlParser.java
+++ b/doxia-modules/doxia-module-xhtml/src/main/java/org/apache/maven/doxia/module/xhtml/XhtmlParser.java
@@ -269,11 +269,11 @@ public class XhtmlParser
         }
         catch ( MacroExecutionException e )
         {
-            throw new XmlPullParserException( "Unable to execute macro in the document: " + macroName , e);
+            throw new XmlPullParserException( "Unable to execute macro in the document: " + macroName , null, e );
         }
         catch ( MacroNotFoundException me )
         {
-            throw new XmlPullParserException( "Macro not found: " + macroName, me);
+            throw new XmlPullParserException( "Macro not found: " + macroName, null, me );
         }
     }
 


### PR DESCRIPTION
The exceptions are swallowed this is really unpractical when using the library (example building a site using mvn-site plugin).