### PR TITLE
[DOXIA-649] Plexus to Sisu migration missed Singleton

### DIFF
--- a/doxia-core/src/main/java/org/apache/maven/doxia/DefaultDoxia.java
+++ b/doxia-core/src/main/java/org/apache/maven/doxia/DefaultDoxia.java
@@ -21,6 +21,7 @@ package org.apache.maven.doxia;
 
 import javax.inject.Inject;
 import javax.inject.Named;
+import javax.inject.Singleton;
 
 import org.apache.maven.doxia.parser.ParseException;
 import org.apache.maven.doxia.parser.Parser;
@@ -37,6 +38,7 @@ import java.io.Reader;
  * @author Jason van Zyl
  * @since 1.0
  */
+@Singleton
 @Named
 public class DefaultDoxia
     implements Doxia

--- a/doxia-core/src/main/java/org/apache/maven/doxia/Doxia.java
+++ b/doxia-core/src/main/java/org/apache/maven/doxia/Doxia.java
@@ -34,8 +34,6 @@ import java.io.Reader;
  */
 public interface Doxia
 {
-    /** The Plexus lookup role. */
-    String ROLE = Doxia.class.getName();
 
     /**
      * Parses the given source model using a parser with given id,

--- a/doxia-core/src/main/java/org/apache/maven/doxia/macro/EchoMacro.java
+++ b/doxia-core/src/main/java/org/apache/maven/doxia/macro/EchoMacro.java
@@ -20,6 +20,7 @@ package org.apache.maven.doxia.macro;
  */
 
 import javax.inject.Named;
+import javax.inject.Singleton;
 
 import org.apache.maven.doxia.sink.Sink;
 import org.apache.maven.doxia.sink.impl.SinkEventAttributeSet;
@@ -27,6 +28,7 @@ import org.apache.maven.doxia.sink.impl.SinkEventAttributeSet;
 /**
  * A simple macro that prints out the key and value of some supplied parameters.
  */
+@Singleton
 @Named( "echo" )
 public class EchoMacro
     extends AbstractMacro

--- a/doxia-core/src/main/java/org/apache/maven/doxia/macro/Macro.java
+++ b/doxia-core/src/main/java/org/apache/maven/doxia/macro/Macro.java
@@ -29,8 +29,6 @@ import org.apache.maven.doxia.sink.Sink;
  */
 public interface Macro
 {
-    /** The Plexus lookup role. */
-    String ROLE = Macro.class.getName();
 
     /** The vm line separator */
     String EOL = System.getProperty( "line.separator" );

--- a/doxia-core/src/main/java/org/apache/maven/doxia/macro/manager/DefaultMacroManager.java
+++ b/doxia-core/src/main/java/org/apache/maven/doxia/macro/manager/DefaultMacroManager.java
@@ -21,6 +21,7 @@ package org.apache.maven.doxia.macro.manager;
 
 import javax.inject.Inject;
 import javax.inject.Named;
+import javax.inject.Singleton;
 
 import org.apache.maven.doxia.macro.Macro;
 
@@ -32,6 +33,7 @@ import java.util.Map;
  * @author <a href="mailto:jason@maven.org">Jason van Zyl</a>
  * @since 1.0
  */
+@Singleton
 @Named
 public class DefaultMacroManager
     implements MacroManager

--- a/doxia-core/src/main/java/org/apache/maven/doxia/macro/manager/MacroManager.java
+++ b/doxia-core/src/main/java/org/apache/maven/doxia/macro/manager/MacroManager.java
@@ -29,8 +29,6 @@ import org.apache.maven.doxia.macro.Macro;
  */
 public interface MacroManager
 {
-    /** The Plexus lookup role. */
-    String ROLE = MacroManager.class.getName();
 
     /**
      * Returns the MacroManager that corresponds to the given id.

--- a/doxia-core/src/main/java/org/apache/maven/doxia/macro/snippet/SnippetMacro.java
+++ b/doxia-core/src/main/java/org/apache/maven/doxia/macro/snippet/SnippetMacro.java
@@ -20,6 +20,7 @@ package org.apache.maven.doxia.macro.snippet;
  */
 
 import javax.inject.Named;
+import javax.inject.Singleton;
 
 import org.apache.maven.doxia.macro.AbstractMacro;
 import org.apache.maven.doxia.macro.MacroExecutionException;
@@ -40,6 +41,7 @@ import java.util.Map;
 /**
  * A macro that prints out the content of a file or a URL.
  */
+@Singleton
 @Named( "snippet" )
 public class SnippetMacro
     extends AbstractMacro

--- a/doxia-core/src/main/java/org/apache/maven/doxia/macro/toc/TocMacro.java
+++ b/doxia-core/src/main/java/org/apache/maven/doxia/macro/toc/TocMacro.java
@@ -20,6 +20,7 @@ package org.apache.maven.doxia.macro.toc;
  */
 
 import javax.inject.Named;
+import javax.inject.Singleton;
 
 import java.io.StringReader;
 
@@ -76,6 +77,7 @@ import org.codehaus.plexus.util.StringUtils;
  *
  * @author <a href="mailto:vincent.siveton@gmail.com">Vincent Siveton</a>
  */
+@Singleton
 @Named( "toc" )
 public class TocMacro
     extends AbstractMacro

--- a/doxia-core/src/main/java/org/apache/maven/doxia/parser/Parser.java
+++ b/doxia-core/src/main/java/org/apache/maven/doxia/parser/Parser.java
@@ -33,8 +33,6 @@ import java.io.Reader;
  */
 public interface Parser
 {
-    /** The Plexus lookup role. */
-    String ROLE = Parser.class.getName();
 
     /** Unknown parser type */
     int UNKNOWN_TYPE = 0;

--- a/doxia-core/src/main/java/org/apache/maven/doxia/parser/manager/DefaultParserManager.java
+++ b/doxia-core/src/main/java/org/apache/maven/doxia/parser/manager/DefaultParserManager.java
@@ -21,6 +21,7 @@ package org.apache.maven.doxia.parser.manager;
 
 import javax.inject.Inject;
 import javax.inject.Named;
+import javax.inject.Singleton;
 
 import org.apache.maven.doxia.parser.Parser;
 
@@ -32,6 +33,7 @@ import java.util.Map;
  * @author <a href="mailto:jason@maven.org">Jason van Zyl</a>
  * @since 1.0
  */
+@Singleton
 @Named
 public class DefaultParserManager
     implements ParserManager

--- a/doxia-core/src/main/java/org/apache/maven/doxia/parser/manager/ParserManager.java
+++ b/doxia-core/src/main/java/org/apache/maven/doxia/parser/manager/ParserManager.java
@@ -29,8 +29,6 @@ import org.apache.maven.doxia.parser.Parser;
  */
 public interface ParserManager
 {
-    /** The Plexus lookup role. */
-    String ROLE = ParserManager.class.getName();
 
     /**
      * Returns the parser that corresponds to the given id.

--- a/doxia-core/src/main/java/org/apache/maven/doxia/parser/module/DefaultParserModuleManager.java
+++ b/doxia-core/src/main/java/org/apache/maven/doxia/parser/module/DefaultParserModuleManager.java
@@ -21,6 +21,7 @@ package org.apache.maven.doxia.parser.module;
 
 import javax.inject.Inject;
 import javax.inject.Named;
+import javax.inject.Singleton;
 
 import java.util.Collection;
 import java.util.LinkedHashMap;
@@ -31,6 +32,7 @@ import java.util.Map;
  *
  * @since 1.6
  */
+@Singleton
 @Named
 public class DefaultParserModuleManager
     implements ParserModuleManager

--- a/doxia-modules/doxia-module-apt/src/main/java/org/apache/maven/doxia/module/apt/AptParser.java
+++ b/doxia-modules/doxia-module-apt/src/main/java/org/apache/maven/doxia/module/apt/AptParser.java
@@ -20,6 +20,7 @@ package org.apache.maven.doxia.module.apt;
  */
 
 import javax.inject.Named;
+import javax.inject.Singleton;
 
 import org.apache.maven.doxia.macro.MacroExecutionException;
 import org.apache.maven.doxia.macro.MacroRequest;
@@ -52,6 +53,7 @@ import java.util.StringTokenizer;
  *
  * @since 1.0
  */
+@Singleton
 @Named( "apt" )
 public class AptParser
     extends AbstractTextParser

--- a/doxia-modules/doxia-module-apt/src/main/java/org/apache/maven/doxia/module/apt/AptParserModule.java
+++ b/doxia-modules/doxia-module-apt/src/main/java/org/apache/maven/doxia/module/apt/AptParserModule.java
@@ -20,6 +20,7 @@ package org.apache.maven.doxia.module.apt;
  */
 
 import javax.inject.Named;
+import javax.inject.Singleton;
 
 import org.apache.maven.doxia.parser.module.AbstractParserModule;
 
@@ -28,6 +29,7 @@ import org.apache.maven.doxia.parser.module.AbstractParserModule;
  *
  * @since 1.6
  */
+@Singleton
 @Named( "apt" )
 public class AptParserModule
     extends AbstractParserModule

--- a/doxia-modules/doxia-module-apt/src/main/java/org/apache/maven/doxia/module/apt/AptSinkFactory.java
+++ b/doxia-modules/doxia-module-apt/src/main/java/org/apache/maven/doxia/module/apt/AptSinkFactory.java
@@ -20,6 +20,7 @@ package org.apache.maven.doxia.module.apt;
  */
 
 import javax.inject.Named;
+import javax.inject.Singleton;
 
 import java.io.Writer;
 
@@ -32,6 +33,7 @@ import org.apache.maven.doxia.sink.impl.AbstractTextSinkFactory;
  * @author <a href="mailto:vincent.siveton@gmail.com">Vincent Siveton</a>
  * @since 1.0
  */
+@Singleton
 @Named( "apt" )
 public class AptSinkFactory
     extends AbstractTextSinkFactory

--- a/doxia-modules/doxia-module-fml/src/main/java/org/apache/maven/doxia/module/fml/FmlParser.java
+++ b/doxia-modules/doxia-module-fml/src/main/java/org/apache/maven/doxia/module/fml/FmlParser.java
@@ -28,6 +28,7 @@ import java.util.Iterator;
 import java.util.Map;
 
 import javax.inject.Named;
+import javax.inject.Singleton;
 import javax.swing.text.html.HTML.Attribute;
 
 import org.apache.maven.doxia.macro.MacroExecutionException;
@@ -57,6 +58,7 @@ import org.slf4j.LoggerFactory;
  * @author ltheussl
  * @since 1.0
  */
+@Singleton
 @Named( "fml" )
 public class FmlParser
     extends AbstractXmlParser

--- a/doxia-modules/doxia-module-fml/src/main/java/org/apache/maven/doxia/module/fml/FmlParserModule.java
+++ b/doxia-modules/doxia-module-fml/src/main/java/org/apache/maven/doxia/module/fml/FmlParserModule.java
@@ -20,6 +20,7 @@ package org.apache.maven.doxia.module.fml;
  */
 
 import javax.inject.Named;
+import javax.inject.Singleton;
 
 import org.apache.maven.doxia.parser.module.AbstractParserModule;
 
@@ -28,6 +29,7 @@ import org.apache.maven.doxia.parser.module.AbstractParserModule;
  *
  * @since 1.6
  */
+@Singleton
 @Named( "fml" )
 public class FmlParserModule
     extends AbstractParserModule

--- a/doxia-modules/doxia-module-markdown/src/main/java/org/apache/maven/doxia/module/markdown/MarkdownParser.java
+++ b/doxia-modules/doxia-module-markdown/src/main/java/org/apache/maven/doxia/module/markdown/MarkdownParser.java
@@ -68,15 +68,10 @@ import java.util.regex.Pattern;
  * @since 1.3
  */
 @Singleton
-@Named( MarkdownParser.ROLE_HINT )
+@Named( "markdown" )
 public class MarkdownParser
     extends AbstractParser
 {
-
-    /**
-     * The role hint for the {@link MarkdownParser} Plexus component.
-     */
-    public static final String ROLE_HINT = "markdown";
 
     /**
      * Regex that identifies a multimarkdown-style metadata section at the start of the document

--- a/doxia-modules/doxia-module-markdown/src/main/java/org/apache/maven/doxia/module/markdown/MarkdownParser.java
+++ b/doxia-modules/doxia-module-markdown/src/main/java/org/apache/maven/doxia/module/markdown/MarkdownParser.java
@@ -21,6 +21,7 @@ package org.apache.maven.doxia.module.markdown;
 
 import javax.inject.Inject;
 import javax.inject.Named;
+import javax.inject.Singleton;
 
 import com.vladsch.flexmark.ast.Heading;
 import com.vladsch.flexmark.ast.HtmlCommentBlock;
@@ -66,6 +67,7 @@ import java.util.regex.Pattern;
  * @author Julien Nicoulaud
  * @since 1.3
  */
+@Singleton
 @Named( MarkdownParser.ROLE_HINT )
 public class MarkdownParser
     extends AbstractParser

--- a/doxia-modules/doxia-module-markdown/src/main/java/org/apache/maven/doxia/module/markdown/MarkdownParserModule.java
+++ b/doxia-modules/doxia-module-markdown/src/main/java/org/apache/maven/doxia/module/markdown/MarkdownParserModule.java
@@ -49,6 +49,6 @@ public class MarkdownParserModule
      */
     public MarkdownParserModule()
     {
-        super( MarkdownParser.ROLE_HINT, MarkdownParser.ROLE_HINT, FILE_EXTENSION, ALTERNATE_FILE_EXTENSION );
+        super( "markdown", "markdown", FILE_EXTENSION, ALTERNATE_FILE_EXTENSION );
     }
 }

--- a/doxia-modules/doxia-module-markdown/src/main/java/org/apache/maven/doxia/module/markdown/MarkdownParserModule.java
+++ b/doxia-modules/doxia-module-markdown/src/main/java/org/apache/maven/doxia/module/markdown/MarkdownParserModule.java
@@ -20,6 +20,7 @@ package org.apache.maven.doxia.module.markdown;
  */
 
 import javax.inject.Named;
+import javax.inject.Singleton;
 
 import org.apache.maven.doxia.parser.module.AbstractParserModule;
 
@@ -28,6 +29,7 @@ import org.apache.maven.doxia.parser.module.AbstractParserModule;
  *
  * @since 1.6
  */
+@Singleton
 @Named( "markdown" )
 public class MarkdownParserModule
     extends AbstractParserModule

--- a/doxia-modules/doxia-module-xdoc/src/main/java/org/apache/maven/doxia/module/xdoc/XdocParser.java
+++ b/doxia-modules/doxia-module-xdoc/src/main/java/org/apache/maven/doxia/module/xdoc/XdocParser.java
@@ -27,6 +27,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import javax.inject.Named;
+import javax.inject.Singleton;
 import javax.swing.text.html.HTML.Attribute;
 
 import org.apache.maven.doxia.macro.MacroExecutionException;
@@ -50,6 +51,7 @@ import org.slf4j.LoggerFactory;
  * @author <a href="mailto:jason@maven.org">Jason van Zyl</a>
  * @since 1.0
  */
+@Singleton
 @Named( "xdoc" )
 public class XdocParser
     extends XhtmlBaseParser

--- a/doxia-modules/doxia-module-xdoc/src/main/java/org/apache/maven/doxia/module/xdoc/XdocParserModule.java
+++ b/doxia-modules/doxia-module-xdoc/src/main/java/org/apache/maven/doxia/module/xdoc/XdocParserModule.java
@@ -20,6 +20,7 @@ package org.apache.maven.doxia.module.xdoc;
  */
 
 import javax.inject.Named;
+import javax.inject.Singleton;
 
 import org.apache.maven.doxia.parser.module.AbstractParserModule;
 
@@ -28,6 +29,7 @@ import org.apache.maven.doxia.parser.module.AbstractParserModule;
  *
  * @since 1.6
  */
+@Singleton
 @Named( "xdoc" )
 public class XdocParserModule
     extends AbstractParserModule

--- a/doxia-modules/doxia-module-xdoc/src/main/java/org/apache/maven/doxia/module/xdoc/XdocSinkFactory.java
+++ b/doxia-modules/doxia-module-xdoc/src/main/java/org/apache/maven/doxia/module/xdoc/XdocSinkFactory.java
@@ -20,6 +20,7 @@ package org.apache.maven.doxia.module.xdoc;
  */
 
 import javax.inject.Named;
+import javax.inject.Singleton;
 
 import java.io.Writer;
 
@@ -32,6 +33,7 @@ import org.apache.maven.doxia.sink.impl.AbstractXmlSinkFactory;
  * @author <a href="mailto:vincent.siveton@gmail.com">Vincent Siveton</a>
  * @since 1.0
  */
+@Singleton
 @Named( "xdoc" )
 public class XdocSinkFactory
     extends AbstractXmlSinkFactory

--- a/doxia-modules/doxia-module-xhtml/src/main/java/org/apache/maven/doxia/module/xhtml/XhtmlParser.java
+++ b/doxia-modules/doxia-module-xhtml/src/main/java/org/apache/maven/doxia/module/xhtml/XhtmlParser.java
@@ -27,6 +27,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import javax.inject.Named;
+import javax.inject.Singleton;
 import javax.swing.text.html.HTML.Attribute;
 
 import org.apache.maven.doxia.macro.MacroExecutionException;
@@ -49,6 +50,7 @@ import org.slf4j.LoggerFactory;
  * @author <a href="mailto:jason@maven.org">Jason van Zyl</a>
  * @since 1.0
  */
+@Singleton
 @Named( "xhtml" )
 public class XhtmlParser
     extends XhtmlBaseParser

--- a/doxia-modules/doxia-module-xhtml/src/main/java/org/apache/maven/doxia/module/xhtml/XhtmlParserModule.java
+++ b/doxia-modules/doxia-module-xhtml/src/main/java/org/apache/maven/doxia/module/xhtml/XhtmlParserModule.java
@@ -20,6 +20,7 @@ package org.apache.maven.doxia.module.xhtml;
  */
 
 import javax.inject.Named;
+import javax.inject.Singleton;
 
 import org.apache.maven.doxia.parser.module.AbstractParserModule;
 
@@ -28,6 +29,7 @@ import org.apache.maven.doxia.parser.module.AbstractParserModule;
  *
  * @since 1.6
  */
+@Singleton
 @Named( "xhtml" )
 public class XhtmlParserModule
     extends AbstractParserModule

--- a/doxia-modules/doxia-module-xhtml/src/main/java/org/apache/maven/doxia/module/xhtml/XhtmlSinkFactory.java
+++ b/doxia-modules/doxia-module-xhtml/src/main/java/org/apache/maven/doxia/module/xhtml/XhtmlSinkFactory.java
@@ -20,6 +20,7 @@ package org.apache.maven.doxia.module.xhtml;
  */
 
 import javax.inject.Named;
+import javax.inject.Singleton;
 
 import java.io.Writer;
 
@@ -32,6 +33,7 @@ import org.apache.maven.doxia.sink.impl.AbstractXmlSinkFactory;
  * @author <a href="mailto:vincent.siveton@gmail.com">Vincent Siveton</a>
  * @since 1.0
  */
+@Singleton
 @Named( "xhtml" )
 public class XhtmlSinkFactory
     extends AbstractXmlSinkFactory

--- a/doxia-modules/doxia-module-xhtml5/src/main/java/org/apache/maven/doxia/module/xhtml5/Xhtml5Parser.java
+++ b/doxia-modules/doxia-module-xhtml5/src/main/java/org/apache/maven/doxia/module/xhtml5/Xhtml5Parser.java
@@ -27,6 +27,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import javax.inject.Named;
+import javax.inject.Singleton;
 import javax.swing.text.html.HTML.Attribute;
 
 import org.apache.maven.doxia.macro.MacroExecutionException;
@@ -46,6 +47,7 @@ import org.slf4j.LoggerFactory;
 /**
  * Parse an xhtml model and emit events into a Doxia Sink.
  */
+@Singleton
 @Named( Xhtml5Parser.ROLE_HINT )
 public class Xhtml5Parser
     extends Xhtml5BaseParser

--- a/doxia-modules/doxia-module-xhtml5/src/main/java/org/apache/maven/doxia/module/xhtml5/Xhtml5Parser.java
+++ b/doxia-modules/doxia-module-xhtml5/src/main/java/org/apache/maven/doxia/module/xhtml5/Xhtml5Parser.java
@@ -48,17 +48,12 @@ import org.slf4j.LoggerFactory;
  * Parse an xhtml model and emit events into a Doxia Sink.
  */
 @Singleton
-@Named( Xhtml5Parser.ROLE_HINT )
+@Named( "xhtml5" )
 public class Xhtml5Parser
     extends Xhtml5BaseParser
     implements Xhtml5Markup
 {
     private static final Logger LOGGER = LoggerFactory.getLogger( Xhtml5Parser.class );
-
-    /**
-     * The role hint for the {@link Xhtml5Parser} Plexus component.
-     */
-    public static final String ROLE_HINT = "xhtml5";
 
     /** For boxed verbatim. */
     private boolean boxed;

--- a/doxia-modules/doxia-module-xhtml5/src/main/java/org/apache/maven/doxia/module/xhtml5/Xhtml5ParserModule.java
+++ b/doxia-modules/doxia-module-xhtml5/src/main/java/org/apache/maven/doxia/module/xhtml5/Xhtml5ParserModule.java
@@ -20,12 +20,14 @@ package org.apache.maven.doxia.module.xhtml5;
  */
 
 import javax.inject.Named;
+import javax.inject.Singleton;
 
 import org.apache.maven.doxia.parser.module.AbstractParserModule;
 
 /**
  * <p>Xhtml5ParserModule class.</p>
  */
+@Singleton
 @Named( "xhtml5" )
 public class Xhtml5ParserModule
     extends AbstractParserModule

--- a/doxia-modules/doxia-module-xhtml5/src/main/java/org/apache/maven/doxia/module/xhtml5/Xhtml5SinkFactory.java
+++ b/doxia-modules/doxia-module-xhtml5/src/main/java/org/apache/maven/doxia/module/xhtml5/Xhtml5SinkFactory.java
@@ -20,6 +20,7 @@ package org.apache.maven.doxia.module.xhtml5;
  */
 
 import javax.inject.Named;
+import javax.inject.Singleton;
 
 import java.io.Writer;
 
@@ -29,6 +30,7 @@ import org.apache.maven.doxia.sink.impl.AbstractXmlSinkFactory;
 /**
  * Xhtml implementation of the Sink factory.
  */
+@Singleton
 @Named( "xhtml5" )
 public class Xhtml5SinkFactory
     extends AbstractXmlSinkFactory

--- a/doxia-sink-api/src/main/java/org/apache/maven/doxia/sink/Sink.java
+++ b/doxia-sink-api/src/main/java/org/apache/maven/doxia/sink/Sink.java
@@ -55,8 +55,6 @@ package org.apache.maven.doxia.sink;
  */
 public interface Sink
 {
-    /** The Plexus Sink Role. */
-    String ROLE = Sink.class.getName();
 
     /**
      * A numbering to handle a number list.

--- a/doxia-sink-api/src/main/java/org/apache/maven/doxia/sink/SinkFactory.java
+++ b/doxia-sink-api/src/main/java/org/apache/maven/doxia/sink/SinkFactory.java
@@ -31,8 +31,6 @@ import java.io.OutputStream;
  */
 public interface SinkFactory
 {
-    /** The Plexus SinkFactory Role. */
-    String ROLE = SinkFactory.class.getName();
 
     /**
      * Create a <code>Sink</code> into a file.

--- a/pom.xml
+++ b/pom.xml
@@ -89,6 +89,7 @@ under the License.
     <project.build.outputTimestamp>2022-02-13T21:44:43Z</project.build.outputTimestamp>
     <slf4jVersion>1.7.32</slf4jVersion>
     <junitVersion>5.8.2</junitVersion>
+    <sisuVersion>0.3.5</sisuVersion>
   </properties>
 
   <dependencyManagement>
@@ -183,7 +184,7 @@ under the License.
       <dependency>
         <groupId>org.eclipse.sisu</groupId>
         <artifactId>org.eclipse.sisu.plexus</artifactId>
-        <version>0.3.5</version>
+        <version>${sisuVersion}</version>
       </dependency>
       <dependency>
         <groupId>com.google.inject</groupId>
@@ -279,12 +280,14 @@ under the License.
     </pluginManagement>
     <plugins>
       <plugin>
-        <groupId>org.codehaus.plexus</groupId>
-        <artifactId>plexus-component-metadata</artifactId>
+        <groupId>org.eclipse.sisu</groupId>
+        <artifactId>sisu-maven-plugin</artifactId>
+        <version>${sisuVersion}</version>
         <executions>
           <execution>
             <goals>
-              <goal>generate-metadata</goal>
+              <goal>main-index</goal>
+              <goal>test-index</goal>
             </goals>
           </execution>
         </executions>


### PR DESCRIPTION
Fixing the affected component annotations to remain singletons.

Fixes migration in commit: 9e998a51e60724ed396fb207d4987ea3d04f4b07

---

https://issues.apache.org/jira/browse/DOXIA-649