### PR TITLE
[DOXIA-617] support yaml metadata

### DIFF
--- a/doxia-modules/doxia-module-markdown/src/main/java/org/apache/maven/doxia/module/markdown/MarkdownParser.java
+++ b/doxia-modules/doxia-module-markdown/src/main/java/org/apache/maven/doxia/module/markdown/MarkdownParser.java
@@ -185,6 +185,13 @@ public class MarkdownParser
         html.append( "<html>" );
         html.append( "<head>" );
 
+        // detect yaml style metadata
+        if ( text.startsWith( "---" ) )
+        {
+            // remove the enclosing --- to get back to classical metadata
+            text = text.replaceFirst( "---", "" ).replaceFirst( "---", "" );
+        }
+
         // First, we interpret the "metadata" section of the document and add the corresponding HTML headers
         Matcher metadataMatcher = METADATA_SECTION_PATTERN.matcher( text );
         boolean haveTitle = false;

--- a/doxia-modules/doxia-module-markdown/src/test/java/org/apache/maven/doxia/module/markdown/MarkdownParserTest.java
+++ b/doxia-modules/doxia-module-markdown/src/test/java/org/apache/maven/doxia/module/markdown/MarkdownParserTest.java
@@ -311,7 +311,24 @@ public class MarkdownParserTest
     public void testMetadataSinkEvent()
         throws Exception
     {
-        List<SinkEventElement> eventList = parseFileToEventTestingSink( "metadata" ).getEventList();
+        testMetadataSinkEvent( "metadata" );
+    }
+
+    /**
+     * Assert the metadata is passed through when parsing "metadata-yaml.md".
+     *
+     * @throws Exception if the event list is not correct when parsing the document
+     */
+    public void testMetadataYamlSinkEvent()
+        throws Exception
+    {
+        testMetadataSinkEvent( "metadata-yaml" );
+    }
+
+    private void testMetadataSinkEvent( String doc )
+        throws Exception
+    {
+        List<SinkEventElement> eventList = parseFileToEventTestingSink( doc ).getEventList();
         Iterator<SinkEventElement> it = eventList.iterator();
 
         assertSinkEquals( it, "head", "title", "text", "text", "text", "title_", "author", "text", "author_", "date",

--- a/doxia-modules/doxia-module-markdown/src/test/resources/metadata-yaml.md
+++ b/doxia-modules/doxia-module-markdown/src/test/resources/metadata-yaml.md
@@ -1,0 +1,14 @@
+---
+title: A Title & a 'Test'
+author: Somebody 'Nickname' Great <somebody@somewhere.org>
+date: 2013 © Copyleft
+keywords: maven,doxia,markdown
+---
+
+# The document with look-alike header
+
+copyright: none
+
+## A subheading
+
+Some more text


### PR DESCRIPTION
https://issues.apache.org/jira/browse/DOXIA-617

given the way metadata header are reworked during parsing by Doxia to detect title, I did not use Flexmark Yaml extension but coded detection and removal of the `---` enclosing yaml metadata

unit tests show that "it works! (TM)"