### PR TITLE
[MNG-6825] Replace Plexus IOUtil with IOUtils from commons-io

### DIFF
--- a/doxia-core/pom.xml
+++ b/doxia-core/pom.xml
@@ -49,6 +49,11 @@ under the License.
       <artifactId>plexus-utils</artifactId>
     </dependency>
     <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+      <version>2.11.0</version>
+    </dependency>
+    <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-text</artifactId>
       <version>1.10.0</version>

--- a/doxia-core/src/main/java/org/apache/maven/doxia/macro/snippet/SnippetReader.java
+++ b/doxia-core/src/main/java/org/apache/maven/doxia/macro/snippet/SnippetReader.java
@@ -26,7 +26,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Pattern;
 
-import org.apache.commons.io.IOUtils;
 import org.codehaus.plexus.util.StringUtils;
 
 /**
@@ -127,7 +126,7 @@ public class SnippetReader {
         }
 
         List<String> lines = new ArrayList<>();
-        try (BufferedReader withReader = reader){
+        try (BufferedReader withReader = reader) {
             boolean capture = false;
             String line;
             boolean foundStart = false;

--- a/doxia-core/src/main/java/org/apache/maven/doxia/macro/snippet/SnippetReader.java
+++ b/doxia-core/src/main/java/org/apache/maven/doxia/macro/snippet/SnippetReader.java
@@ -127,13 +127,13 @@ public class SnippetReader {
         }
 
         List<String> lines = new ArrayList<>();
-        try {
+        try (BufferedReader withReader = reader){
             boolean capture = false;
             String line;
             boolean foundStart = false;
             boolean foundEnd = false;
             boolean hasSnippetId = StringUtils.isNotEmpty(snippetId);
-            while ((line = reader.readLine()) != null) {
+            while ((line = withReader.readLine()) != null) {
                 if (!hasSnippetId) {
                     lines.add(line);
                 } else {
@@ -155,8 +155,6 @@ public class SnippetReader {
             if (hasSnippetId && !foundEnd) {
                 throw new IOException("Failed to find END of snippet " + snippetId + " in file at URL: " + source);
             }
-        } finally {
-            IOUtils.close(reader);
         }
         return lines;
     }

--- a/doxia-core/src/main/java/org/apache/maven/doxia/macro/snippet/SnippetReader.java
+++ b/doxia-core/src/main/java/org/apache/maven/doxia/macro/snippet/SnippetReader.java
@@ -26,7 +26,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Pattern;
 
-import org.codehaus.plexus.util.IOUtil;
+import org.apache.commons.io.IOUtils;
 import org.codehaus.plexus.util.StringUtils;
 
 /**
@@ -156,7 +156,7 @@ public class SnippetReader {
                 throw new IOException("Failed to find END of snippet " + snippetId + " in file at URL: " + source);
             }
         } finally {
-            IOUtil.close(reader);
+            IOUtils.close(reader);
         }
         return lines;
     }

--- a/doxia-core/src/main/java/org/apache/maven/doxia/parser/AbstractXmlParser.java
+++ b/doxia-core/src/main/java/org/apache/maven/doxia/parser/AbstractXmlParser.java
@@ -686,17 +686,13 @@ public abstract class AbstractXmlParser extends AbstractParser implements XmlMar
          * @throws SAXException if any
          */
         private static byte[] toByteArray(URL url) throws SAXException {
-            InputStream is = null;
-            try {
-                is = url.openStream();
+            try (InputStream is = url.openStream()) {
                 if (is == null) {
                     throw new SAXException("Cannot open stream from the url: " + url);
                 }
                 return IOUtils.toByteArray(is);
             } catch (IOException e) {
                 throw new SAXException(e);
-            } finally {
-                IOUtils.close(is);
             }
         }
     }

--- a/doxia-core/src/main/java/org/apache/maven/doxia/parser/AbstractXmlParser.java
+++ b/doxia-core/src/main/java/org/apache/maven/doxia/parser/AbstractXmlParser.java
@@ -34,13 +34,13 @@ import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.apache.commons.io.IOUtils;
 import org.apache.maven.doxia.macro.MacroExecutionException;
 import org.apache.maven.doxia.markup.XmlMarkup;
 import org.apache.maven.doxia.sink.Sink;
 import org.apache.maven.doxia.sink.impl.SinkEventAttributeSet;
 import org.apache.maven.doxia.util.HtmlTools;
 import org.apache.maven.doxia.util.XmlValidator;
-import org.codehaus.plexus.util.IOUtil;
 import org.codehaus.plexus.util.StringUtils;
 import org.codehaus.plexus.util.xml.pull.EntityReplacementMap;
 import org.codehaus.plexus.util.xml.pull.MXParser;
@@ -109,7 +109,7 @@ public abstract class AbstractXmlParser extends AbstractParser implements XmlMar
         if (isValidate()) {
             String content;
             try {
-                content = IOUtil.toString(new BufferedReader(src));
+                content = IOUtils.toString(new BufferedReader(src));
             } catch (IOException e) {
                 throw new ParseException("Error reading the model", e);
             }
@@ -692,11 +692,11 @@ public abstract class AbstractXmlParser extends AbstractParser implements XmlMar
                 if (is == null) {
                     throw new SAXException("Cannot open stream from the url: " + url);
                 }
-                return IOUtil.toByteArray(is);
+                return IOUtils.toByteArray(is);
             } catch (IOException e) {
                 throw new SAXException(e);
             } finally {
-                IOUtil.close(is);
+                IOUtils.close(is);
             }
         }
     }

--- a/doxia-core/src/main/java/org/apache/maven/doxia/util/ByLineReaderSource.java
+++ b/doxia-core/src/main/java/org/apache/maven/doxia/util/ByLineReaderSource.java
@@ -28,7 +28,6 @@ import java.io.LineNumberReader;
 import java.io.Reader;
 import java.util.Objects;
 
-import org.apache.commons.io.IOUtils;
 import org.apache.maven.doxia.parser.ParseException;
 
 /**
@@ -138,7 +137,15 @@ public class ByLineReaderSource implements ByLineSource {
      * {@inheritDoc}
      */
     public final void close() {
-        IOUtils.close(reader);
+        if (reader == null) {
+            return;
+        }
+
+        try {
+            reader.close();
+        } catch (IOException ex) {
+            // ignore
+        }
         reader = null;
     }
 

--- a/doxia-core/src/main/java/org/apache/maven/doxia/util/ByLineReaderSource.java
+++ b/doxia-core/src/main/java/org/apache/maven/doxia/util/ByLineReaderSource.java
@@ -28,8 +28,8 @@ import java.io.LineNumberReader;
 import java.io.Reader;
 import java.util.Objects;
 
+import org.apache.commons.io.IOUtils;
 import org.apache.maven.doxia.parser.ParseException;
-import org.codehaus.plexus.util.IOUtil;
 
 /**
  * {@link ByLineSource} default implementation
@@ -138,7 +138,7 @@ public class ByLineReaderSource implements ByLineSource {
      * {@inheritDoc}
      */
     public final void close() {
-        IOUtil.close(reader);
+        IOUtils.close(reader);
         reader = null;
     }
 

--- a/doxia-core/src/main/java/org/apache/maven/doxia/util/LineBreaker.java
+++ b/doxia-core/src/main/java/org/apache/maven/doxia/util/LineBreaker.java
@@ -22,8 +22,6 @@ import java.io.BufferedWriter;
 import java.io.IOException;
 import java.io.Writer;
 
-import org.apache.commons.io.IOUtils;
-
 /**
  * Allows to specify the line-length of an output writer.
  */
@@ -178,6 +176,14 @@ public class LineBreaker {
      * Close the writer.
      */
     public void close() {
-        IOUtils.close(writer);
+        if (writer == null) {
+            return;
+        }
+
+        try {
+            writer.close();
+        } catch (IOException ex) {
+            // ignore
+        }
     }
 }

--- a/doxia-core/src/main/java/org/apache/maven/doxia/util/LineBreaker.java
+++ b/doxia-core/src/main/java/org/apache/maven/doxia/util/LineBreaker.java
@@ -22,7 +22,7 @@ import java.io.BufferedWriter;
 import java.io.IOException;
 import java.io.Writer;
 
-import org.codehaus.plexus.util.IOUtil;
+import org.apache.commons.io.IOUtils;
 
 /**
  * Allows to specify the line-length of an output writer.
@@ -178,6 +178,6 @@ public class LineBreaker {
      * Close the writer.
      */
     public void close() {
-        IOUtil.close(writer);
+        IOUtils.close(writer);
     }
 }

--- a/doxia-core/src/test/java/org/apache/maven/doxia/sink/impl/AbstractSinkTest.java
+++ b/doxia-core/src/test/java/org/apache/maven/doxia/sink/impl/AbstractSinkTest.java
@@ -22,7 +22,6 @@ import java.io.CharArrayWriter;
 import java.io.IOException;
 import java.io.Writer;
 
-import org.apache.commons.io.IOUtils;
 import org.apache.maven.doxia.AbstractModuleTest;
 import org.apache.maven.doxia.sink.Sink;
 import org.apache.maven.doxia.sink.SinkEventAttributes;
@@ -110,7 +109,6 @@ public abstract class AbstractSinkTest extends AbstractModuleTest {
             SinkTestDocument.generate(testSink);
         } finally {
             testSink.close();
-            IOUtils.close(writer);
         }
     }
 

--- a/doxia-core/src/test/java/org/apache/maven/doxia/sink/impl/AbstractSinkTest.java
+++ b/doxia-core/src/test/java/org/apache/maven/doxia/sink/impl/AbstractSinkTest.java
@@ -22,10 +22,10 @@ import java.io.CharArrayWriter;
 import java.io.IOException;
 import java.io.Writer;
 
+import org.apache.commons.io.IOUtils;
 import org.apache.maven.doxia.AbstractModuleTest;
 import org.apache.maven.doxia.sink.Sink;
 import org.apache.maven.doxia.sink.SinkEventAttributes;
-import org.codehaus.plexus.util.IOUtil;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -110,7 +110,7 @@ public abstract class AbstractSinkTest extends AbstractModuleTest {
             SinkTestDocument.generate(testSink);
         } finally {
             testSink.close();
-            IOUtil.close(writer);
+            IOUtils.close(writer);
         }
     }
 

--- a/doxia-core/src/test/java/org/apache/maven/doxia/util/XmlValidatorTest.java
+++ b/doxia-core/src/test/java/org/apache/maven/doxia/util/XmlValidatorTest.java
@@ -18,8 +18,8 @@
  */
 package org.apache.maven.doxia.util;
 
+import org.apache.commons.io.IOUtils;
 import org.codehaus.plexus.testing.PlexusTest;
-import org.codehaus.plexus.util.IOUtil;
 import org.codehaus.plexus.util.xml.XmlStreamReader;
 import org.junit.jupiter.api.Test;
 
@@ -32,7 +32,7 @@ import org.junit.jupiter.api.Test;
 public class XmlValidatorTest {
     @Test
     public void testValidate() throws Exception {
-        String xml = IOUtil.toString(new XmlStreamReader(this.getClass().getResourceAsStream("/test.xml")));
+        String xml = IOUtils.toString(new XmlStreamReader(this.getClass().getResourceAsStream("/test.xml")));
 
         XmlValidator validator = new XmlValidator();
 

--- a/doxia-core/src/test/java/org/apache/maven/doxia/xsd/AbstractXmlValidatorTest.java
+++ b/doxia-core/src/test/java/org/apache/maven/doxia/xsd/AbstractXmlValidatorTest.java
@@ -33,9 +33,9 @@ import java.util.Map;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
 
+import org.apache.commons.io.IOUtils;
 import org.apache.maven.doxia.parser.AbstractXmlParser;
 import org.codehaus.plexus.util.FileUtils;
-import org.codehaus.plexus.util.IOUtil;
 import org.codehaus.plexus.util.ReaderFactory;
 import org.codehaus.plexus.util.SelectorUtils;
 import org.codehaus.plexus.util.xml.XmlUtil;
@@ -148,10 +148,10 @@ public abstract class AbstractXmlValidatorTest extends AbstractXmlValidator {
                             .getClassLoader()
                             .getResource(entry.getName())
                             .openStream();
-                    String content = IOUtil.toString(in, "UTF-8");
+                    String content = IOUtils.toString(in, "UTF-8");
                     CACHE_DOXIA_TEST_DOCUMENTS.put("jar:" + conn.getJarFileURL() + "!/" + entry.getName(), content);
                 } finally {
-                    IOUtil.close(in);
+                    IOUtils.close(in);
                 }
             }
         } else {
@@ -173,7 +173,7 @@ public abstract class AbstractXmlValidatorTest extends AbstractXmlValidator {
                     reader = ReaderFactory.newReader(file, "UTF-8");
                 }
 
-                String content = IOUtil.toString(reader);
+                String content = IOUtils.toString(reader);
                 CACHE_DOXIA_TEST_DOCUMENTS.put(file.toURI().toString(), content);
             }
         }

--- a/doxia-core/src/test/java/org/apache/maven/doxia/xsd/AbstractXmlValidatorTest.java
+++ b/doxia-core/src/test/java/org/apache/maven/doxia/xsd/AbstractXmlValidatorTest.java
@@ -142,16 +142,12 @@ public abstract class AbstractXmlValidatorTest extends AbstractXmlValidator {
                     continue;
                 }
 
-                InputStream in = null;
-                try {
-                    in = AbstractXmlValidatorTest.class
-                            .getClassLoader()
-                            .getResource(entry.getName())
-                            .openStream();
+                try (InputStream in = AbstractXmlValidatorTest.class
+                        .getClassLoader()
+                        .getResource(entry.getName())
+                        .openStream()) {
                     String content = IOUtils.toString(in, "UTF-8");
                     CACHE_DOXIA_TEST_DOCUMENTS.put("jar:" + conn.getJarFileURL() + "!/" + entry.getName(), content);
-                } finally {
-                    IOUtils.close(in);
                 }
             }
         } else {

--- a/doxia-modules/doxia-module-apt/src/main/java/org/apache/maven/doxia/module/apt/AptParser.java
+++ b/doxia-modules/doxia-module-apt/src/main/java/org/apache/maven/doxia/module/apt/AptParser.java
@@ -29,6 +29,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.StringTokenizer;
 
+import org.apache.commons.io.IOUtils;
 import org.apache.maven.doxia.macro.MacroExecutionException;
 import org.apache.maven.doxia.macro.MacroRequest;
 import org.apache.maven.doxia.macro.manager.MacroNotFoundException;
@@ -39,7 +40,6 @@ import org.apache.maven.doxia.sink.SinkEventAttributes;
 import org.apache.maven.doxia.sink.impl.SinkAdapter;
 import org.apache.maven.doxia.sink.impl.SinkEventAttributeSet;
 import org.apache.maven.doxia.util.DoxiaUtils;
-import org.codehaus.plexus.util.IOUtil;
 import org.codehaus.plexus.util.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -190,7 +190,7 @@ public class AptParser extends AbstractTextParser implements AptMarkup {
 
         try {
             StringWriter contentWriter = new StringWriter();
-            IOUtil.copy(source, contentWriter);
+            IOUtils.copy(source, contentWriter);
             sourceContent = contentWriter.toString();
         } catch (IOException e) {
             throw new AptParseException(e);

--- a/doxia-modules/doxia-module-apt/src/main/java/org/apache/maven/doxia/module/apt/AptReaderSource.java
+++ b/doxia-modules/doxia-module-apt/src/main/java/org/apache/maven/doxia/module/apt/AptReaderSource.java
@@ -22,7 +22,7 @@ import java.io.IOException;
 import java.io.LineNumberReader;
 import java.io.Reader;
 
-import org.codehaus.plexus.util.IOUtil;
+import org.apache.commons.io.IOUtils;
 
 /**
  * Reader for apt source documents.
@@ -112,7 +112,7 @@ public class AptReaderSource implements AptSource {
      * Closes the reader associated with this AptReaderSource.
      */
     public void close() {
-        IOUtil.close(reader);
+        IOUtils.close(reader);
         reader = null;
     }
 }

--- a/doxia-modules/doxia-module-apt/src/main/java/org/apache/maven/doxia/module/apt/AptReaderSource.java
+++ b/doxia-modules/doxia-module-apt/src/main/java/org/apache/maven/doxia/module/apt/AptReaderSource.java
@@ -22,8 +22,6 @@ import java.io.IOException;
 import java.io.LineNumberReader;
 import java.io.Reader;
 
-import org.apache.commons.io.IOUtils;
-
 /**
  * Reader for apt source documents.
  */
@@ -112,7 +110,15 @@ public class AptReaderSource implements AptSource {
      * Closes the reader associated with this AptReaderSource.
      */
     public void close() {
-        IOUtils.close(reader);
+        if (reader == null) {
+            return;
+        }
+
+        try {
+            reader.close();
+        } catch (IOException ex) {
+            // ignore
+        }
         reader = null;
     }
 }

--- a/doxia-modules/doxia-module-fml/src/main/java/org/apache/maven/doxia/module/fml/FmlParser.java
+++ b/doxia-modules/doxia-module-fml/src/main/java/org/apache/maven/doxia/module/fml/FmlParser.java
@@ -30,6 +30,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 
+import org.apache.commons.io.IOUtils;
 import org.apache.maven.doxia.macro.MacroExecutionException;
 import org.apache.maven.doxia.macro.MacroRequest;
 import org.apache.maven.doxia.macro.manager.MacroNotFoundException;
@@ -43,7 +44,6 @@ import org.apache.maven.doxia.sink.impl.SinkEventAttributeSet;
 import org.apache.maven.doxia.sink.impl.Xhtml5BaseSink;
 import org.apache.maven.doxia.util.DoxiaUtils;
 import org.apache.maven.doxia.util.HtmlTools;
-import org.codehaus.plexus.util.IOUtil;
 import org.codehaus.plexus.util.StringUtils;
 import org.codehaus.plexus.util.xml.pull.XmlPullParser;
 import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
@@ -91,12 +91,12 @@ public class FmlParser extends AbstractXmlParser implements FmlMarkup {
 
         try {
             StringWriter contentWriter = new StringWriter();
-            IOUtil.copy(source, contentWriter);
+            IOUtils.copy(source, contentWriter);
             sourceContent = contentWriter.toString();
         } catch (IOException ex) {
             throw new ParseException("Error reading the input source", ex);
         } finally {
-            IOUtil.close(source);
+            IOUtils.close(source);
         }
 
         try {

--- a/doxia-modules/doxia-module-fml/src/main/java/org/apache/maven/doxia/module/fml/FmlParser.java
+++ b/doxia-modules/doxia-module-fml/src/main/java/org/apache/maven/doxia/module/fml/FmlParser.java
@@ -89,14 +89,12 @@ public class FmlParser extends AbstractXmlParser implements FmlMarkup {
         this.sourceContent = null;
         init();
 
-        try {
+        try (Reader reader = source) {
             StringWriter contentWriter = new StringWriter();
-            IOUtils.copy(source, contentWriter);
+            IOUtils.copy(reader, contentWriter);
             sourceContent = contentWriter.toString();
         } catch (IOException ex) {
             throw new ParseException("Error reading the input source", ex);
-        } finally {
-            IOUtils.close(source);
         }
 
         try {

--- a/doxia-modules/doxia-module-fml/src/test/java/org/apache/maven/doxia/module/fml/FmlParserTest.java
+++ b/doxia-modules/doxia-module-fml/src/test/java/org/apache/maven/doxia/module/fml/FmlParserTest.java
@@ -28,13 +28,13 @@ import java.io.Writer;
 import java.util.Iterator;
 import java.util.regex.Pattern;
 
+import org.apache.commons.io.IOUtils;
 import org.apache.maven.doxia.parser.AbstractParserTest;
 import org.apache.maven.doxia.parser.Parser;
 import org.apache.maven.doxia.sink.Sink;
 import org.apache.maven.doxia.sink.impl.SinkEventElement;
 import org.apache.maven.doxia.sink.impl.SinkEventTestingSink;
 import org.apache.maven.doxia.sink.impl.Xhtml5BaseSink;
-import org.codehaus.plexus.util.IOUtil;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -266,7 +266,7 @@ public class FmlParserTest extends AbstractParserTest {
 
         String content;
         try (Reader reader = new FileReader(f)) {
-            content = IOUtil.toString(reader);
+            content = IOUtils.toString(reader);
         }
 
         assertTrue(content.contains("<a id=\"macro-definition\"></a>" + EOL + "<dt>Macro Question</dt>"));

--- a/doxia-modules/doxia-module-markdown/src/main/java/org/apache/maven/doxia/module/markdown/MarkdownParser.java
+++ b/doxia-modules/doxia-module-markdown/src/main/java/org/apache/maven/doxia/module/markdown/MarkdownParser.java
@@ -49,6 +49,7 @@ import com.vladsch.flexmark.ext.yaml.front.matter.YamlFrontMatterExtension;
 import com.vladsch.flexmark.html.HtmlRenderer;
 import com.vladsch.flexmark.util.ast.Node;
 import com.vladsch.flexmark.util.data.MutableDataSet;
+import org.apache.commons.io.IOUtils;
 import org.apache.maven.doxia.markup.HtmlMarkup;
 import org.apache.maven.doxia.markup.TextMarkup;
 import org.apache.maven.doxia.module.xhtml5.Xhtml5Parser;
@@ -56,7 +57,6 @@ import org.apache.maven.doxia.parser.AbstractTextParser;
 import org.apache.maven.doxia.parser.ParseException;
 import org.apache.maven.doxia.sink.Sink;
 import org.apache.maven.doxia.util.HtmlTools;
-import org.codehaus.plexus.util.IOUtil;
 import org.codehaus.plexus.util.xml.pull.XmlPullParser;
 
 /**
@@ -267,7 +267,7 @@ public class MarkdownParser extends AbstractTextParser implements TextMarkup {
      */
     String toHtml(Reader source) throws IOException {
         // Read the source
-        StringBuilder markdownText = new StringBuilder(IOUtil.toString(source));
+        StringBuilder markdownText = new StringBuilder(IOUtils.toString(source));
 
         // Now, build the HTML document
         StringBuilder html = new StringBuilder(1000);

--- a/doxia-modules/doxia-module-xdoc/src/main/java/org/apache/maven/doxia/module/xdoc/XdocParser.java
+++ b/doxia-modules/doxia-module-xdoc/src/main/java/org/apache/maven/doxia/module/xdoc/XdocParser.java
@@ -29,6 +29,7 @@ import java.io.StringWriter;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.apache.commons.io.IOUtils;
 import org.apache.maven.doxia.macro.MacroExecutionException;
 import org.apache.maven.doxia.macro.MacroRequest;
 import org.apache.maven.doxia.macro.manager.MacroNotFoundException;
@@ -37,7 +38,6 @@ import org.apache.maven.doxia.parser.Xhtml5BaseParser;
 import org.apache.maven.doxia.sink.Sink;
 import org.apache.maven.doxia.sink.impl.SinkEventAttributeSet;
 import org.apache.maven.doxia.util.HtmlTools;
-import org.codehaus.plexus.util.IOUtil;
 import org.codehaus.plexus.util.StringUtils;
 import org.codehaus.plexus.util.xml.pull.XmlPullParser;
 import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
@@ -91,12 +91,12 @@ public class XdocParser extends Xhtml5BaseParser implements XdocMarkup {
 
         try {
             StringWriter contentWriter = new StringWriter();
-            IOUtil.copy(source, contentWriter);
+            IOUtils.copy(source, contentWriter);
             sourceContent = contentWriter.toString();
         } catch (IOException ex) {
             throw new ParseException("Error reading the input source", ex);
         } finally {
-            IOUtil.close(source);
+            IOUtils.close(source);
         }
 
         // leave this at default (false) until everything is properly implemented, see DOXIA-226

--- a/doxia-modules/doxia-module-xdoc/src/main/java/org/apache/maven/doxia/module/xdoc/XdocParser.java
+++ b/doxia-modules/doxia-module-xdoc/src/main/java/org/apache/maven/doxia/module/xdoc/XdocParser.java
@@ -89,14 +89,12 @@ public class XdocParser extends Xhtml5BaseParser implements XdocMarkup {
     public void parse(Reader source, Sink sink, String reference) throws ParseException {
         this.sourceContent = null;
 
-        try {
+        try (Reader reader = source) {
             StringWriter contentWriter = new StringWriter();
-            IOUtils.copy(source, contentWriter);
+            IOUtils.copy(reader, contentWriter);
             sourceContent = contentWriter.toString();
         } catch (IOException ex) {
             throw new ParseException("Error reading the input source", ex);
-        } finally {
-            IOUtils.close(source);
         }
 
         // leave this at default (false) until everything is properly implemented, see DOXIA-226

--- a/doxia-modules/doxia-module-xdoc/src/test/java/org/apache/maven/doxia/module/xdoc/XdocParserTest.java
+++ b/doxia-modules/doxia-module-xdoc/src/test/java/org/apache/maven/doxia/module/xdoc/XdocParserTest.java
@@ -28,6 +28,7 @@ import java.io.Writer;
 import java.util.Iterator;
 import java.util.regex.Pattern;
 
+import org.apache.commons.io.IOUtils;
 import org.apache.maven.doxia.parser.AbstractParserTest;
 import org.apache.maven.doxia.parser.ParseException;
 import org.apache.maven.doxia.parser.Parser;
@@ -35,7 +36,6 @@ import org.apache.maven.doxia.sink.Sink;
 import org.apache.maven.doxia.sink.impl.SinkEventAttributeSet;
 import org.apache.maven.doxia.sink.impl.SinkEventElement;
 import org.apache.maven.doxia.sink.impl.SinkEventTestingSink;
-import org.codehaus.plexus.util.IOUtil;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -110,7 +110,7 @@ public class XdocParserTest extends AbstractParserTest {
 
         String content;
         try (Reader reader = new FileReader(f)) {
-            content = IOUtil.toString(reader);
+            content = IOUtils.toString(reader);
         }
 
         assertTrue(content.contains("&lt;modelVersion&gt;4.0.0&lt;/modelVersion&gt;"));
@@ -130,7 +130,7 @@ public class XdocParserTest extends AbstractParserTest {
 
         String content;
         try (Reader reader = new FileReader(f)) {
-            content = IOUtil.toString(reader);
+            content = IOUtils.toString(reader);
         }
 
         // No section, only subsection 1 and 2

--- a/doxia-modules/doxia-module-xhtml5/src/main/java/org/apache/maven/doxia/module/xhtml5/Xhtml5Parser.java
+++ b/doxia-modules/doxia-module-xhtml5/src/main/java/org/apache/maven/doxia/module/xhtml5/Xhtml5Parser.java
@@ -29,6 +29,7 @@ import java.io.StringWriter;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.apache.commons.io.IOUtils;
 import org.apache.maven.doxia.macro.MacroExecutionException;
 import org.apache.maven.doxia.macro.MacroRequest;
 import org.apache.maven.doxia.macro.manager.MacroNotFoundException;
@@ -36,7 +37,6 @@ import org.apache.maven.doxia.parser.ParseException;
 import org.apache.maven.doxia.parser.Xhtml5BaseParser;
 import org.apache.maven.doxia.sink.Sink;
 import org.apache.maven.doxia.sink.impl.SinkEventAttributeSet;
-import org.codehaus.plexus.util.IOUtil;
 import org.codehaus.plexus.util.StringUtils;
 import org.codehaus.plexus.util.xml.pull.XmlPullParser;
 import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
@@ -273,12 +273,12 @@ public class Xhtml5Parser extends Xhtml5BaseParser implements Xhtml5Markup {
 
         try {
             StringWriter contentWriter = new StringWriter();
-            IOUtil.copy(source, contentWriter);
+            IOUtils.copy(source, contentWriter);
             sourceContent = contentWriter.toString();
         } catch (IOException ex) {
             throw new ParseException("Error reading the input source", ex);
         } finally {
-            IOUtil.close(source);
+            IOUtils.close(source);
         }
 
         try {

--- a/doxia-modules/doxia-module-xhtml5/src/main/java/org/apache/maven/doxia/module/xhtml5/Xhtml5Parser.java
+++ b/doxia-modules/doxia-module-xhtml5/src/main/java/org/apache/maven/doxia/module/xhtml5/Xhtml5Parser.java
@@ -271,14 +271,12 @@ public class Xhtml5Parser extends Xhtml5BaseParser implements Xhtml5Markup {
     public void parse(Reader source, Sink sink, String reference) throws ParseException {
         this.sourceContent = null;
 
-        try {
+        try (Reader reader = source) {
             StringWriter contentWriter = new StringWriter();
-            IOUtils.copy(source, contentWriter);
+            IOUtils.copy(reader, contentWriter);
             sourceContent = contentWriter.toString();
         } catch (IOException ex) {
             throw new ParseException("Error reading the input source", ex);
-        } finally {
-            IOUtils.close(source);
         }
 
         try {


### PR DESCRIPTION
For https://issues.apache.org/jira/browse/MNG-6825

This third PR targets IOUtil, which was not present in apache/maven, hence I've targeted the project that uses it the most.

Regrettably some manual fixes where needed, as the replacement commons-io IOUtils does not silently swallow IOExceptions like Plexus IOUtil did. Hence inlined the old behaviour a couple times and adopted try-with-resources a few other times.

Not entirely happy both with the process for these replacements and with the outcomes. PR opened to gather feedback on whether we would want to target the other replacements similarly, or adopt a different approach, such as more try-with-resources, or no commons-io IOUtils.