### PR TITLE
Fix snippet reader tab and indent handling

### DIFF
--- a/doxia-core/src/main/java/org/apache/maven/doxia/macro/snippet/SnippetReader.java
+++ b/doxia-core/src/main/java/org/apache/maven/doxia/macro/snippet/SnippetReader.java
@@ -73,7 +73,9 @@ public class SnippetReader {
         int minIndent = minIndent(lines);
         StringBuffer result = new StringBuffer();
         for (String line : lines) {
-            result.append(line.substring(minIndent));
+            if (line.length() > minIndent) {
+                result.append(line.substring(minIndent));
+            }
             result.append(EOL);
         }
         return result;
@@ -88,6 +90,9 @@ public class SnippetReader {
     int minIndent(List<String> lines) {
         int minIndent = Integer.MAX_VALUE;
         for (String line : lines) {
+            if (StringUtils.isBlank(line)) {
+                continue;
+            }
             minIndent = Math.min(minIndent, indent(line));
         }
         return minIndent;
@@ -103,7 +108,7 @@ public class SnippetReader {
         char[] chars = line.toCharArray();
         int indent = 0;
         for (; indent < chars.length; indent++) {
-            if (chars[indent] != ' ') {
+            if (chars[indent] != ' ' && chars[indent] != '\t') {
                 break;
             }
         }

--- a/doxia-core/src/test/resources/macro/snippet/testSnippet-indent.txt
+++ b/doxia-core/src/test/resources/macro/snippet/testSnippet-indent.txt
@@ -1,0 +1,40 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+preamble
+
+SNIPPET START firstId
+		first snippet
+SNIPPET END   firstId
+
+interlude
+
+another snippet to start: secondId
+    second snippet
+another snippet to end:   secondId
+
+snippet start thirdId
+		Line1
+			Line2
+
+	
+		
+			
+				Line6
+snippet end thirdId
+
+conclusion


### PR DESCRIPTION
The PR addresses the following issues:

* The snippet reader did not correctly apply the indentation for snippet sources which were indented using tabs. The minIndent calculation only checked spaces.

Snippet Source:
```
[tab][tab]line
```

Old Behaviour
```
[tab][tab]line
```

New Behaviour:
```
line
```


* The snippet reader minIndent calculation was always 0 whenever the snippet contained empty newlines. Those empty lines will now correctly be handled.

Snippet Source:
```
[space][space]line1
[\n]
[space]line2
```

Old Behaviour
```
[space][space]line1
[\n]
[space]line2
```

New Behaviour:
```
line1
[\n]
[space]line2
```
