### PR TITLE
[MNG-6829] Replace any StringUtils#isEmpty(String) and #isNotEmpty(String)

### DIFF
--- a/doxia-core/src/main/java/org/apache/maven/doxia/index/IndexEntry.java
+++ b/doxia-core/src/main/java/org/apache/maven/doxia/index/IndexEntry.java
@@ -22,8 +22,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import org.apache.commons.lang3.StringUtils;
-
 /**
  * <p>IndexEntry class.</p>
  *
@@ -264,7 +262,7 @@ public class IndexEntry {
 
         message.append("Id: ").append(id);
 
-        if (StringUtils.isNotEmpty(title)) {
+        if (title != null && !title.isEmpty()) {
             message.append(", title: ").append(title);
         }
 

--- a/doxia-core/src/main/java/org/apache/maven/doxia/macro/snippet/SnippetMacro.java
+++ b/doxia-core/src/main/java/org/apache/maven/doxia/macro/snippet/SnippetMacro.java
@@ -28,7 +28,6 @@ import java.net.URL;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.maven.doxia.macro.AbstractMacro;
 import org.apache.maven.doxia.macro.MacroExecutionException;
 import org.apache.maven.doxia.macro.MacroRequest;
@@ -112,13 +111,13 @@ public class SnippetMacro extends AbstractMacro {
 
         URL url;
 
-        if (!StringUtils.isEmpty(urlParam)) {
+        if (!(urlParam == null || urlParam.isEmpty())) {
             try {
                 url = new URL(urlParam);
             } catch (MalformedURLException e) {
                 throw new IllegalArgumentException(urlParam + " is a malformed URL", e);
             }
-        } else if (!StringUtils.isEmpty(fileParam)) {
+        } else if (!(fileParam == null || fileParam.isEmpty())) {
             File f = new File(fileParam);
 
             if (!f.isAbsolute()) {
@@ -267,7 +266,7 @@ public class SnippetMacro extends AbstractMacro {
      *         or just url.toString() if id is empty or null.
      */
     private String globalSnippetId(URL url, String id) {
-        if (StringUtils.isEmpty(id)) {
+        if (id == null || id.isEmpty()) {
             return url.toString();
         }
 

--- a/doxia-core/src/main/java/org/apache/maven/doxia/macro/snippet/SnippetReader.java
+++ b/doxia-core/src/main/java/org/apache/maven/doxia/macro/snippet/SnippetReader.java
@@ -26,8 +26,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Pattern;
 
-import org.apache.commons.lang3.StringUtils;
-
 /**
  * Utility class for reading snippets.
  */
@@ -131,7 +129,7 @@ public class SnippetReader {
             String line;
             boolean foundStart = false;
             boolean foundEnd = false;
-            boolean hasSnippetId = StringUtils.isNotEmpty(snippetId);
+            boolean hasSnippetId = snippetId != null && !snippetId.isEmpty();
             while ((line = withReader.readLine()) != null) {
                 if (!hasSnippetId) {
                     lines.add(line);

--- a/doxia-core/src/main/java/org/apache/maven/doxia/macro/toc/TocMacro.java
+++ b/doxia-core/src/main/java/org/apache/maven/doxia/macro/toc/TocMacro.java
@@ -23,7 +23,6 @@ import javax.inject.Singleton;
 
 import java.io.StringReader;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.maven.doxia.index.IndexEntry;
 import org.apache.maven.doxia.index.IndexingSink;
 import org.apache.maven.doxia.macro.AbstractMacro;
@@ -181,7 +180,7 @@ public class TocMacro extends AbstractMacro {
     private static int getInt(MacroRequest request, String parameter, int defaultValue) throws MacroExecutionException {
         String value = (String) request.getParameter(parameter);
 
-        if (StringUtils.isEmpty(value)) {
+        if (value == null || value.isEmpty()) {
             return defaultValue;
         }
 

--- a/doxia-core/src/main/java/org/apache/maven/doxia/parser/AbstractXmlParser.java
+++ b/doxia-core/src/main/java/org/apache/maven/doxia/parser/AbstractXmlParser.java
@@ -273,7 +273,7 @@ public abstract class AbstractXmlParser extends AbstractParser implements XmlMar
          * NOTE: Don't do any whitespace trimming here. Whitespace normalization has already been performed by the
          * parser so any whitespace that makes it here is significant.
          */
-        if (StringUtils.isNotEmpty(text)) {
+        if (text != null && !text.isEmpty()) {
             sink.text(text);
         }
     }

--- a/doxia-core/src/main/java/org/apache/maven/doxia/parser/Xhtml5BaseParser.java
+++ b/doxia-core/src/main/java/org/apache/maven/doxia/parser/Xhtml5BaseParser.java
@@ -26,7 +26,6 @@ import java.util.Set;
 import java.util.Stack;
 import java.util.regex.Pattern;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.maven.doxia.macro.MacroExecutionException;
 import org.apache.maven.doxia.markup.HtmlMarkup;
 import org.apache.maven.doxia.sink.Sink;
@@ -320,9 +319,9 @@ public class Xhtml5BaseParser extends AbstractXmlParser implements HtmlMarkup {
                 sink.definitionListItem(attribs);
             }
             sink.definition(attribs);
-        } else if ((parser.getName().equals(HtmlMarkup.FIGURE.toString()))) {
+        } else if (parser.getName().equals(HtmlMarkup.FIGURE.toString())) {
             sink.figure(attribs);
-        } else if ((parser.getName().equals(HtmlMarkup.FIGCAPTION.toString()))) {
+        } else if (parser.getName().equals(HtmlMarkup.FIGCAPTION.toString())) {
             sink.figureCaption(attribs);
         } else if (parser.getName().equals(HtmlMarkup.A.toString())) {
             handleAStart(parser, sink, attribs);
@@ -403,9 +402,9 @@ public class Xhtml5BaseParser extends AbstractXmlParser implements HtmlMarkup {
             sink.definition_();
             sink.definitionListItem_();
             hasDefinitionListItem = false;
-        } else if ((parser.getName().equals(HtmlMarkup.FIGURE.toString()))) {
+        } else if (parser.getName().equals(HtmlMarkup.FIGURE.toString())) {
             sink.figure_();
-        } else if ((parser.getName().equals(HtmlMarkup.FIGCAPTION.toString()))) {
+        } else if (parser.getName().equals(HtmlMarkup.FIGCAPTION.toString())) {
             sink.figureCaption_();
         } else if (parser.getName().equals(HtmlMarkup.A.toString())) {
             handleAEnd(sink);
@@ -563,7 +562,7 @@ public class Xhtml5BaseParser extends AbstractXmlParser implements HtmlMarkup {
          *
          * NOTE: text within script tags is ignored, scripting code should be embedded in CDATA.
          */
-        if (StringUtils.isNotEmpty(text) && !isScriptBlock()) {
+        if ((text != null && !text.isEmpty()) && !isScriptBlock()) {
             sink.text(text);
         }
     }

--- a/doxia-modules/doxia-module-fml/src/main/java/org/apache/maven/doxia/module/fml/FmlParser.java
+++ b/doxia-modules/doxia-module-fml/src/main/java/org/apache/maven/doxia/module/fml/FmlParser.java
@@ -264,7 +264,7 @@ public class FmlParser extends AbstractXmlParser implements FmlMarkup {
         else if (parser.getName().equals(MACRO_TAG.toString())) {
             handleMacroEnd(buffer);
         } else if (parser.getName().equals(PARAM.toString())) {
-            if (!StringUtils.isNotEmpty(macroName)) {
+            if (!(macroName != null && !macroName.isEmpty())) {
                 handleUnknown(parser, sink, TAG_TYPE_END);
             }
         } else if (buffer != null) {
@@ -369,7 +369,7 @@ public class FmlParser extends AbstractXmlParser implements FmlMarkup {
                 macroParameters = new HashMap<>();
             }
 
-            if (StringUtils.isEmpty(macroName)) {
+            if (macroName == null || macroName.isEmpty()) {
                 throw new MacroExecutionException("The '" + Attribute.NAME.toString() + "' attribute for the '"
                         + MACRO_TAG.toString() + "' tag is required.");
             }
@@ -384,7 +384,7 @@ public class FmlParser extends AbstractXmlParser implements FmlMarkup {
      */
     private void handleMacroEnd(StringBuilder buffer) throws MacroExecutionException {
         if (!isSecondParsing()) {
-            if (StringUtils.isNotEmpty(macroName)) {
+            if (macroName != null && !macroName.isEmpty()) {
                 MacroRequest request = new MacroRequest(sourceContent, new FmlParser(), macroParameters, getBasedir());
 
                 try {
@@ -413,11 +413,11 @@ public class FmlParser extends AbstractXmlParser implements FmlMarkup {
      */
     private void handleParamStart(XmlPullParser parser, Sink sink) throws MacroExecutionException {
         if (!isSecondParsing()) {
-            if (StringUtils.isNotEmpty(macroName)) {
+            if (macroName != null && !macroName.isEmpty()) {
                 String paramName = parser.getAttributeValue(null, Attribute.NAME.toString());
                 String paramValue = parser.getAttributeValue(null, Attribute.VALUE.toString());
 
-                if (StringUtils.isEmpty(paramName) || StringUtils.isEmpty(paramValue)) {
+                if ((paramName == null || paramName.isEmpty()) || (paramValue == null || paramValue.isEmpty())) {
                     throw new MacroExecutionException("'" + Attribute.NAME.toString()
                             + "' and '" + Attribute.VALUE.toString() + "' attributes for the '" + PARAM.toString()
                             + "' tag are required inside the '" + MACRO_TAG.toString() + "' tag.");

--- a/doxia-modules/doxia-module-xdoc/src/main/java/org/apache/maven/doxia/module/xdoc/XdocParser.java
+++ b/doxia-modules/doxia-module-xdoc/src/main/java/org/apache/maven/doxia/module/xdoc/XdocParser.java
@@ -30,7 +30,6 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.maven.doxia.macro.MacroExecutionException;
 import org.apache.maven.doxia.macro.MacroRequest;
 import org.apache.maven.doxia.macro.manager.MacroNotFoundException;
@@ -221,7 +220,7 @@ public class XdocParser extends Xhtml5BaseParser implements XdocMarkup {
         } else if (parser.getName().equals(MACRO_TAG.toString())) {
             handleMacroEnd(sink);
         } else if (parser.getName().equals(PARAM.toString())) {
-            if (!StringUtils.isNotEmpty(macroName)) {
+            if (!(macroName != null && !macroName.isEmpty())) {
                 handleUnknown(parser, sink, TAG_TYPE_END);
             }
         } else if (parser.getName().equals(SECTION_TAG.toString())) {
@@ -282,7 +281,7 @@ public class XdocParser extends Xhtml5BaseParser implements XdocMarkup {
     }
 
     private void handleMacroEnd(Sink sink) throws MacroExecutionException {
-        if (!isSecondParsing() && StringUtils.isNotEmpty(macroName)) {
+        if (!isSecondParsing() && (macroName != null && !macroName.isEmpty())) {
             MacroRequest request = new MacroRequest(sourceContent, new XdocParser(), macroParameters, getBasedir());
 
             try {
@@ -305,7 +304,7 @@ public class XdocParser extends Xhtml5BaseParser implements XdocMarkup {
                 macroParameters = new HashMap<>();
             }
 
-            if (StringUtils.isEmpty(macroName)) {
+            if (macroName == null || macroName.isEmpty()) {
                 throw new MacroExecutionException("The '" + Attribute.NAME.toString() + "' attribute for the '"
                         + MACRO_TAG.toString() + "' tag is required.");
             }
@@ -331,11 +330,11 @@ public class XdocParser extends Xhtml5BaseParser implements XdocMarkup {
 
     private void handleParamStart(XmlPullParser parser, Sink sink) throws MacroExecutionException {
         if (!isSecondParsing()) {
-            if (StringUtils.isNotEmpty(macroName)) {
+            if (macroName != null && !macroName.isEmpty()) {
                 String paramName = parser.getAttributeValue(null, Attribute.NAME.toString());
                 String paramValue = parser.getAttributeValue(null, Attribute.VALUE.toString());
 
-                if (StringUtils.isEmpty(paramName) || StringUtils.isEmpty(paramValue)) {
+                if ((paramName == null || paramName.isEmpty()) || (paramValue == null || paramValue.isEmpty())) {
                     throw new MacroExecutionException(
                             "'" + Attribute.NAME.toString() + "' and '" + Attribute.VALUE.toString()
                                     + "' attributes for the '" + PARAM.toString() + "' tag are required inside the '"


### PR DESCRIPTION
Continuation of https://issues.apache.org/jira/browse/MNG-6829

Review requested of @elharo

Use this link to re-run the recipe: https://public.moderne.io/recipes/org.openrewrite.java.migrate.apache.commons.lang.IsNotEmptyToJdk?organizationId=QXBhY2hlIE1hdmVu