### PR TITLE
[DOXIA-726] Incorrect escaping of <,>,",' and &

### DIFF
--- a/doxia-modules/doxia-module-markdown/src/main/java/org/apache/maven/doxia/module/markdown/MarkdownSink.java
+++ b/doxia-modules/doxia-module-markdown/src/main/java/org/apache/maven/doxia/module/markdown/MarkdownSink.java
@@ -33,6 +33,7 @@ import org.apache.maven.doxia.sink.Sink;
 import org.apache.maven.doxia.sink.SinkEventAttributes;
 import org.apache.maven.doxia.sink.impl.AbstractTextSink;
 import org.apache.maven.doxia.sink.impl.SinkEventAttributeSet;
+import org.apache.maven.doxia.util.HtmlTools;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -760,7 +761,7 @@ public class MarkdownSink extends AbstractTextSink implements MarkdownMarkup {
     /**
      * {@inheritDoc}
      *
-     * Unkown events just log a warning message but are ignored otherwise.
+     * Unknown events just log a warning message but are ignored otherwise.
      * @see org.apache.maven.doxia.sink.Sink#unknown(String,Object[],SinkEventAttributes)
      */
     @Override
@@ -819,7 +820,8 @@ public class MarkdownSink extends AbstractTextSink implements MarkdownMarkup {
     // ----------------------------------------------------------------------
 
     /**
-     * Escape special characters in a text in Markdown:
+     * First use XML escaping (leveraging the predefined entities, for browsers)
+     * afterwards escape special characters in a text with a leading backslash (for markdown parsers)
      *
      * <pre>
      * \, `, *, _, {, }, [, ], (, ), #, +, -, ., !
@@ -833,7 +835,7 @@ public class MarkdownSink extends AbstractTextSink implements MarkdownMarkup {
         if (text == null) {
             return "";
         }
-
+        text = HtmlTools.escapeHTML(text, true); // assume UTF-8 output, i.e. only use the mandatory XML entities
         int length = text.length();
         StringBuilder buffer = new StringBuilder(length);
 

--- a/doxia-modules/doxia-module-markdown/src/test/java/org/apache/maven/doxia/module/markdown/MarkdownSinkTest.java
+++ b/doxia-modules/doxia-module-markdown/src/test/java/org/apache/maven/doxia/module/markdown/MarkdownSinkTest.java
@@ -32,6 +32,7 @@ import org.apache.maven.doxia.parser.Parser;
 import org.apache.maven.doxia.sink.Sink;
 import org.apache.maven.doxia.sink.impl.AbstractSinkTest;
 import org.apache.maven.doxia.sink.impl.SinkEventTestingSink;
+import org.apache.maven.doxia.util.HtmlTools;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
@@ -315,7 +316,11 @@ public class MarkdownSinkTest extends AbstractSinkTest {
 
     /** {@inheritDoc} */
     protected String getTextBlock(String text) {
-        return getEscapedText(text);
+        // this is only called once, therefore hard-code the expected result
+        // return escaped format of "~,_=,_-,_+,_*,_[,_],_<,_>,_{,_},_\\";
+        // i.e. XML entities for <>&"' and Markdown escape sequences for characters outlined in
+        // https://daringfireball.net/projects/markdown/syntax#backslash
+        return "~,\\_=,\\_\\-,\\_\\+,\\_\\*,\\_\\[,\\_\\],\\_&lt;,\\_&gt;,\\_\\{,\\_\\},\\_\\\\";
     }
 
     /** {@inheritDoc} */
@@ -329,6 +334,7 @@ public class MarkdownSinkTest extends AbstractSinkTest {
      * @return the text with all special characters escaped
      */
     private String getEscapedText(String text) {
+        text = HtmlTools.escapeHTML(text, true);
         return text.replaceAll("\\\\|\\`|\\*|_|\\{|\\}|\\[|\\]|\\(|\\)|#|\\+|\\-|\\.|\\!", "\\\\$0");
     }
 


### PR DESCRIPTION
Use XML entities prior to escaping for Markdown with a backslash