### PR TITLE
[DOXIA-731] Simplify HTML markup emitted from Sink.verbatim

### DIFF
--- a/doxia-core/src/test/java/org/apache/maven/doxia/parser/Xhtml5BaseParserTest.java
+++ b/doxia-core/src/test/java/org/apache/maven/doxia/parser/Xhtml5BaseParserTest.java
@@ -36,7 +36,7 @@ public class Xhtml5BaseParserTest extends AbstractParserTest {
     private final SinkEventTestingSink sink = new SinkEventTestingSink();
 
     @Override
-    protected Parser createParser() {
+    protected AbstractParser createParser() {
         parser = new Xhtml5BaseParser();
         return parser;
     }
@@ -930,5 +930,15 @@ public class Xhtml5BaseParserTest extends AbstractParserTest {
                 "definedTerm_",
                 "definitionListItem_",
                 "definitionList_");
+    }
+
+    @Override
+    protected String getVerbatimSource() {
+        return "<pre>&lt;&gt;{}=#*</pre>";
+    }
+
+    @Override
+    protected String getVerbatimCodeSource() {
+        return "<pre><code>&lt;&gt;{}=#*</code></pre>";
     }
 }

--- a/doxia-core/src/test/java/org/apache/maven/doxia/sink/impl/SinkTestDocument.java
+++ b/doxia-core/src/test/java/org/apache/maven/doxia/sink/impl/SinkTestDocument.java
@@ -81,8 +81,10 @@ public class SinkTestDocument {
 
         generateList(sink);
 
-        sink.verbatim(SinkEventAttributeSet.SOURCE);
+        sink.verbatim();
+        sink.inline(SinkEventAttributeSet.Semantics.CODE);
         sink.text("Verbatim source text not contained in list item 3");
+        sink.inline_();
         sink.verbatim_();
 
         generateNumberedList(sink);
@@ -258,8 +260,10 @@ public class SinkTestDocument {
         sink.definedTerm_();
         sink.definition();
         sink.text("of definition list.");
-        sink.verbatim(SinkEventAttributeSet.SOURCE);
+        sink.verbatim();
+        sink.inline(SinkEventAttributeSet.Semantics.CODE);
         sink.text("Verbatim source text" + eol + "                        in a box        ");
+        sink.inline_();
         sink.verbatim_();
         sink.definition_();
         sink.definitionListItem_();

--- a/doxia-core/src/test/java/org/apache/maven/doxia/sink/impl/Xhtml5BaseSinkTest.java
+++ b/doxia-core/src/test/java/org/apache/maven/doxia/sink/impl/Xhtml5BaseSinkTest.java
@@ -651,28 +651,27 @@ public class Xhtml5BaseSinkTest {
      * Test of verbatim method, of class Xhtml5BaseSink.
      */
     @Test
-    public void testVerbatimSource() {
+    public void testVerbatim() {
         try (Xhtml5BaseSink sink = new Xhtml5BaseSink(writer)) {
             sink.verbatim(SinkEventAttributeSet.SOURCE);
             sink.verbatim_();
         }
 
-        assertEquals("<div class=\"verbatim source\">" + LS + "<pre></pre></div>", writer.toString());
+        assertEquals("<pre><code></code></pre>", writer.toString());
 
-        checkVerbatimAttributes(attributes, "<div class=\"verbatim\">" + LS + "<pre style=\"bold\"></pre></div>");
+        checkVerbatimAttributes(attributes, "<pre style=\"bold\"></pre>");
 
         final SinkEventAttributes att = new SinkEventAttributeSet(SinkEventAttributes.ID, "id");
-        checkVerbatimAttributes(att, "<div class=\"verbatim\">" + LS + "<pre id=\"id\"></pre></div>");
+        checkVerbatimAttributes(att, "<pre id=\"id\"></pre>");
 
         att.addAttribute(Attribute.CLASS, "class");
-        checkVerbatimAttributes(att, "<div class=\"verbatim\">" + LS + "<pre id=\"id\" class=\"class\"></pre></div>");
+        checkVerbatimAttributes(att, "<pre id=\"id\" class=\"class\"></pre>");
 
         att.addAttribute(SinkEventAttributes.DECORATION, "source");
-        checkVerbatimAttributes(
-                att, "<div class=\"verbatim source\">" + LS + "<pre id=\"id\" class=\"class\"></pre></div>");
+        checkVerbatimAttributes(att, "<pre id=\"id\" class=\"class\"><code></code></pre>");
 
         att.removeAttribute(Attribute.CLASS.toString());
-        checkVerbatimAttributes(att, "<div class=\"verbatim source\">" + LS + "<pre id=\"id\"></pre></div>");
+        checkVerbatimAttributes(att, "<pre id=\"id\"><code></code></pre>");
     }
 
     private void checkVerbatimAttributes(final SinkEventAttributes att, final String expected) {

--- a/doxia-modules/doxia-module-apt/src/test/java/org/apache/maven/doxia/module/apt/AptParserTest.java
+++ b/doxia-modules/doxia-module-apt/src/test/java/org/apache/maven/doxia/module/apt/AptParserTest.java
@@ -26,9 +26,9 @@ import java.io.StringWriter;
 import java.io.Writer;
 import java.util.Iterator;
 
+import org.apache.maven.doxia.parser.AbstractParser;
 import org.apache.maven.doxia.parser.AbstractParserTest;
 import org.apache.maven.doxia.parser.ParseException;
-import org.apache.maven.doxia.parser.Parser;
 import org.apache.maven.doxia.sink.Sink;
 import org.apache.maven.doxia.sink.impl.SinkEventAttributeSet;
 import org.apache.maven.doxia.sink.impl.SinkEventElement;
@@ -47,7 +47,7 @@ public class AptParserTest extends AbstractParserTest {
     @Inject
     private AptParser parser;
 
-    protected Parser createParser() {
+    protected AbstractParser createParser() {
         return parser;
     }
 
@@ -522,7 +522,28 @@ public class AptParserTest extends AbstractParserTest {
         assertSinkEquals(sink.getEventList().get(8), "text", "Another author", null);
     }
 
+    @Override
     protected String outputExtension() {
         return "apt";
+    }
+
+    @Override
+    protected void assertEventPrefix(Iterator<SinkEventElement> eventIterator) {
+        assertSinkStartsWith(eventIterator, "head", "head_", "body");
+    }
+
+    @Override
+    protected void assertEventSuffix(Iterator<SinkEventElement> eventIterator) {
+        assertSinkEquals(eventIterator, "body_");
+    }
+
+    @Override
+    protected String getVerbatimSource() {
+        return "---" + EOL + "<>{}=#*" + EOL + "---" + EOL;
+    }
+
+    @Override
+    protected String getVerbatimCodeSource() {
+        return "+--" + EOL + "<>{}=#*" + EOL + "+--" + EOL;
     }
 }

--- a/doxia-modules/doxia-module-fml/src/test/java/org/apache/maven/doxia/module/fml/FmlParserTest.java
+++ b/doxia-modules/doxia-module-fml/src/test/java/org/apache/maven/doxia/module/fml/FmlParserTest.java
@@ -29,8 +29,8 @@ import java.util.Iterator;
 import java.util.regex.Pattern;
 
 import org.apache.commons.io.IOUtils;
+import org.apache.maven.doxia.parser.AbstractParser;
 import org.apache.maven.doxia.parser.AbstractParserTest;
-import org.apache.maven.doxia.parser.Parser;
 import org.apache.maven.doxia.sink.Sink;
 import org.apache.maven.doxia.sink.impl.SinkEventElement;
 import org.apache.maven.doxia.sink.impl.SinkEventTestingSink;
@@ -73,7 +73,7 @@ public class FmlParserTest extends AbstractParserTest {
     }
 
     /** {@inheritDoc} */
-    protected Parser createParser() {
+    protected AbstractParser createParser() {
         return parser;
     }
 
@@ -270,6 +270,65 @@ public class FmlParserTest extends AbstractParserTest {
         }
 
         assertTrue(content.contains("<a id=\"macro-definition\"></a>" + EOL + "<dt>Macro Question</dt>"));
+    }
+
+    @Override
+    protected void assertEventPrefix(Iterator<SinkEventElement> eventIterator) {
+        assertSinkStartsWith(
+                eventIterator,
+                "head",
+                "title",
+                "text",
+                "title_",
+                "head_",
+                "body",
+                "section1",
+                "anchor",
+                "anchor_",
+                "sectionTitle1",
+                "text",
+                "sectionTitle1_",
+                "numberedList",
+                "numberedListItem",
+                "link",
+                "link_",
+                "numberedListItem_",
+                "numberedList_",
+                "section1_",
+                "definitionList",
+                "anchor",
+                "anchor_",
+                "definedTerm",
+                "definedTerm_",
+                "definition");
+    }
+
+    @Override
+    protected void assertEventSuffix(Iterator<SinkEventElement> eventIterator) {
+        assertSinkEquals(
+                eventIterator,
+                "paragraph",
+                "link",
+                "text",
+                "link_",
+                "paragraph_",
+                "definition_",
+                "definitionList_",
+                "body_");
+    }
+
+    @Override
+    protected String getVerbatimSource() {
+        return "<faqs title=\"title\"><part id=\"general\"><faq id=\"first\"><question></question><answer>"
+                + "<pre>&lt;&gt;{}=#*</pre>"
+                + "</answer></faq></part></faqs>";
+    }
+
+    @Override
+    protected String getVerbatimCodeSource() {
+        return "<faqs title=\"title\"><part id=\"general\"><faq id=\"first\"><question></question><answer>"
+                + "<source>&lt;&gt;{}=#*</source>"
+                + "</answer></faq></part></faqs>";
     }
 
     private void assertTextEvent(SinkEventElement textEvt, String string) {

--- a/doxia-modules/doxia-module-markdown/src/test/java/org/apache/maven/doxia/module/markdown/MarkdownParserTest.java
+++ b/doxia-modules/doxia-module-markdown/src/test/java/org/apache/maven/doxia/module/markdown/MarkdownParserTest.java
@@ -813,7 +813,11 @@ public class MarkdownParserTest extends AbstractParserTest {
 
     @Override
     protected String getVerbatimSource() {
-        return null; // not supported in MD
+        /**
+         * Markdown doesn't support verbatim text which is not code:
+         * https://spec.commonmark.org/0.31.2/#fenced-code-blocks and https://spec.commonmark.org/0.31.2/#indented-code-blocks
+         */
+        return null;
     }
 
     @Override

--- a/doxia-modules/doxia-module-markdown/src/test/java/org/apache/maven/doxia/module/markdown/MarkdownParserTest.java
+++ b/doxia-modules/doxia-module-markdown/src/test/java/org/apache/maven/doxia/module/markdown/MarkdownParserTest.java
@@ -25,9 +25,9 @@ import java.io.Reader;
 import java.util.Iterator;
 import java.util.List;
 
+import org.apache.maven.doxia.parser.AbstractParser;
 import org.apache.maven.doxia.parser.AbstractParserTest;
 import org.apache.maven.doxia.parser.ParseException;
-import org.apache.maven.doxia.parser.Parser;
 import org.apache.maven.doxia.sink.SinkEventAttributes;
 import org.apache.maven.doxia.sink.impl.SinkEventAttributeSet;
 import org.apache.maven.doxia.sink.impl.SinkEventElement;
@@ -56,7 +56,7 @@ public class MarkdownParserTest extends AbstractParserTest {
      * {@inheritDoc}
      */
     @Override
-    protected Parser createParser() {
+    protected AbstractParser createParser() {
         return parser;
     }
 
@@ -205,12 +205,12 @@ public class MarkdownParserTest extends AbstractParserTest {
 
         assertFalse(it.hasNext());
 
-        // PRE element must be a "verbatim" Sink event that specifies
-        // SOURCE = true
+        // PRE element must be a "verbatim" Sink event
         SinkEventElement pre = eventList.get(7);
         assertEquals("verbatim", pre.getName());
         SinkEventAttributeSet preAtts = (SinkEventAttributeSet) pre.getArgs()[0];
-        assertFalse(preAtts.containsAttribute(SinkEventAttributes.DECORATION, "source"));
+        // instead of using a decoration tag on the verbatim event and additional inline event is used
+        assertTrue(preAtts.isEmpty());
 
         // * CODE element must be an "inline" Sink event that specifies:
         // * SEMANTICS = "code" and CLASS = "language-java"
@@ -778,12 +778,14 @@ public class MarkdownParserTest extends AbstractParserTest {
     }
 
     // test fix for https://github.com/vsch/flexmark-java/issues/384
+    @Test
     public void testFlexIssue384() throws Exception {
         parseFileToEventTestingSink("flex-384");
     }
 
     // Apostrophe versus single quotes
     // Simple apostrophes (like in Sophie's Choice) must not be replaced with a single quote
+    @Test
     public void testQuoteVsApostrophe() throws Exception {
         List<SinkEventElement> eventList =
                 parseFileToEventTestingSink("quote-vs-apostrophe").getEventList();
@@ -797,5 +799,25 @@ public class MarkdownParserTest extends AbstractParserTest {
         assertEquals(
                 "This apostrophe isn't a quote." + "This \u2018quoted text\u2019 isn't surrounded by apostrophes.",
                 content.toString());
+    }
+
+    @Override
+    protected void assertEventPrefix(Iterator<SinkEventElement> eventIterator) {
+        assertSinkStartsWith(eventIterator, "head", "head_", "body");
+    }
+
+    @Override
+    protected void assertEventSuffix(Iterator<SinkEventElement> eventIterator) {
+        assertSinkEquals(eventIterator, "body_");
+    }
+
+    @Override
+    protected String getVerbatimSource() {
+        return null; // not supported in MD
+    }
+
+    @Override
+    protected String getVerbatimCodeSource() {
+        return "```" + EOL + "<>{}=#*" + EOL + "```";
     }
 }

--- a/doxia-modules/doxia-module-xdoc/src/main/java/org/apache/maven/doxia/module/xdoc/XdocSink.java
+++ b/doxia-modules/doxia-module-xdoc/src/main/java/org/apache/maven/doxia/module/xdoc/XdocSink.java
@@ -44,9 +44,6 @@ public class XdocSink extends Xhtml5BaseSink implements XdocMarkup {
     // Instance fields
     // ----------------------------------------------------------------------
 
-    /** An indication on if we're inside verbatim source. */
-    private boolean sourceFlag;
-
     private String encoding;
 
     private String languageId;
@@ -104,8 +101,6 @@ public class XdocSink extends Xhtml5BaseSink implements XdocMarkup {
      */
     protected void init() {
         super.init();
-
-        sourceFlag = false;
     }
 
     /**
@@ -340,7 +335,6 @@ public class XdocSink extends Xhtml5BaseSink implements XdocMarkup {
      * @param attributes a {@link org.apache.maven.doxia.sink.SinkEventAttributes} object.
      */
     public void verbatim(SinkEventAttributes attributes) {
-        setVerbatimFlag(true);
 
         MutableAttributeSet atts = SinkUtils.filterAttributes(attributes, SinkUtils.SINK_VERBATIM_ATTRIBUTES);
 
@@ -348,15 +342,16 @@ public class XdocSink extends Xhtml5BaseSink implements XdocMarkup {
             atts = new SinkEventAttributeSet();
         }
 
-        boolean source = false;
-
+        this.setVerbatimMode(VerbatimMode.ON);
         if (atts.isDefined(SinkEventAttributes.DECORATION)) {
-            sourceFlag = source = "source".equals(atts.getAttribute(SinkEventAttributes.DECORATION));
+            if ("source".equals(atts.getAttribute(SinkEventAttributes.DECORATION))) {
+                this.setVerbatimMode(VerbatimMode.ON_WITH_CODE);
+            }
         }
 
         atts.removeAttribute(SinkEventAttributes.DECORATION);
 
-        if (source) {
+        if (getVerbatimMode() == VerbatimMode.ON_WITH_CODE) {
             writeStartTag(SOURCE_TAG, atts);
         } else {
             writeStartTag(PRE, atts);
@@ -370,15 +365,13 @@ public class XdocSink extends Xhtml5BaseSink implements XdocMarkup {
      * @see javax.swing.text.html.HTML.Tag#PRE
      */
     public void verbatim_() {
-        if (sourceFlag) {
+        if (getVerbatimMode() == VerbatimMode.ON_WITH_CODE) {
             writeEndTag(SOURCE_TAG);
         } else {
             writeEndTag(PRE);
         }
 
-        setVerbatimFlag(false);
-
-        sourceFlag = false;
+        this.setVerbatimMode(VerbatimMode.OFF);
     }
 
     /**

--- a/doxia-modules/doxia-module-xdoc/src/test/java/org/apache/maven/doxia/module/xdoc/XdocParserTest.java
+++ b/doxia-modules/doxia-module-xdoc/src/test/java/org/apache/maven/doxia/module/xdoc/XdocParserTest.java
@@ -29,9 +29,9 @@ import java.util.Iterator;
 import java.util.regex.Pattern;
 
 import org.apache.commons.io.IOUtils;
+import org.apache.maven.doxia.parser.AbstractParser;
 import org.apache.maven.doxia.parser.AbstractParserTest;
 import org.apache.maven.doxia.parser.ParseException;
-import org.apache.maven.doxia.parser.Parser;
 import org.apache.maven.doxia.sink.Sink;
 import org.apache.maven.doxia.sink.impl.SinkEventAttributeSet;
 import org.apache.maven.doxia.sink.impl.SinkEventElement;
@@ -91,7 +91,7 @@ public class XdocParserTest extends AbstractParserTest {
     }
 
     /** {@inheritDoc} */
-    protected Parser createParser() {
+    protected AbstractParser createParser() {
         return parser;
     }
 
@@ -429,5 +429,15 @@ public class XdocParserTest extends AbstractParserTest {
         assertEquals("unknown", styleElm_.getName());
         assertEquals("style", styleElm_.getArgs()[0]);
         assertFalse(it.hasNext());
+    }
+
+    @Override
+    protected String getVerbatimSource() {
+        return "<pre><![CDATA[<>{}=#*]]></pre>";
+    }
+
+    @Override
+    protected String getVerbatimCodeSource() {
+        return "<source><![CDATA[<>{}=#*]]></source>";
     }
 }

--- a/doxia-modules/doxia-module-xhtml5/src/test/java/org/apache/maven/doxia/module/xhtml5/Xhtml5ParserTest.java
+++ b/doxia-modules/doxia-module-xhtml5/src/test/java/org/apache/maven/doxia/module/xhtml5/Xhtml5ParserTest.java
@@ -25,8 +25,8 @@ import java.io.FileFilter;
 import java.util.Iterator;
 import java.util.regex.Pattern;
 
+import org.apache.maven.doxia.parser.AbstractParser;
 import org.apache.maven.doxia.parser.AbstractParserTest;
-import org.apache.maven.doxia.parser.Parser;
 import org.apache.maven.doxia.sink.impl.SinkEventElement;
 import org.apache.maven.doxia.sink.impl.SinkEventTestingSink;
 import org.junit.jupiter.api.BeforeEach;
@@ -63,7 +63,7 @@ public class Xhtml5ParserTest extends AbstractParserTest {
     }
 
     /** {@inheritDoc} */
-    protected Parser createParser() {
+    protected AbstractParser createParser() {
         return parser;
     }
 
@@ -180,5 +180,15 @@ public class Xhtml5ParserTest extends AbstractParserTest {
         assertEquals("list_", it.next().getName());
         assertEquals("listItem_", it.next().getName());
         assertEquals("list_", it.next().getName());
+    }
+
+    @Override
+    protected String getVerbatimSource() {
+        return null; // already tested in Xhtml5BaseParserTest
+    }
+
+    @Override
+    protected String getVerbatimCodeSource() {
+        return null; // already tested in Xhtml5BaseParserTest
     }
 }

--- a/doxia-modules/doxia-module-xhtml5/src/test/java/org/apache/maven/doxia/module/xhtml5/Xhtml5SinkTest.java
+++ b/doxia-modules/doxia-module-xhtml5/src/test/java/org/apache/maven/doxia/module/xhtml5/Xhtml5SinkTest.java
@@ -259,7 +259,7 @@ public class Xhtml5SinkTest extends AbstractSinkTest {
 
     /** {@inheritDoc} */
     protected String getVerbatimSourceBlock(String text) {
-        return "<div class=\"verbatim source\">\n<pre>" + text + "</pre></div>";
+        return "<pre><code>" + text + "</code></pre>";
     }
 
     /** {@inheritDoc} */


### PR DESCRIPTION
Use either `<pre>` or `<pre><code>`.
Add parser tests for verbatim content (for all parsers)