### PR TITLE
[DOXIA-732] Don't fail for duplicate anchor names

### DIFF
--- a/doxia-core/src/main/java/org/apache/maven/doxia/sink/impl/SinkWrapper.java
+++ b/doxia-core/src/main/java/org/apache/maven/doxia/sink/impl/SinkWrapper.java
@@ -19,6 +19,7 @@
 package org.apache.maven.doxia.sink.impl;
 
 import org.apache.maven.doxia.parser.Parser;
+import org.apache.maven.doxia.sink.Locator;
 import org.apache.maven.doxia.sink.Sink;
 import org.apache.maven.doxia.sink.SinkEventAttributes;
 
@@ -525,5 +526,15 @@ public class SinkWrapper extends AbstractSink {
     @Override
     public void close() {
         delegate.close();
+    }
+
+    @Override
+    public void setDocumentLocator(Locator locator) {
+        delegate.setDocumentLocator(locator);
+    }
+
+    @Override
+    public Locator getDocumentLocator() {
+        return delegate.getDocumentLocator();
     }
 }

--- a/doxia-core/src/main/java/org/apache/maven/doxia/sink/impl/UniqueAnchorNamesValidator.java
+++ b/doxia-core/src/main/java/org/apache/maven/doxia/sink/impl/UniqueAnchorNamesValidator.java
@@ -23,11 +23,15 @@ import java.util.Set;
 
 import org.apache.maven.doxia.sink.Sink;
 import org.apache.maven.doxia.sink.SinkEventAttributes;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Validates that each anchor name only appears once per document. Otherwise fails with an {@link IllegalStateException}.
  */
 public class UniqueAnchorNamesValidator extends SinkWrapper {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(UniqueAnchorNamesValidator.class);
 
     private final Set<String> usedAnchorNames;
 
@@ -46,8 +50,7 @@ public class UniqueAnchorNamesValidator extends SinkWrapper {
 
     private void enforceUniqueAnchor(String name) {
         if (!usedAnchorNames.add(name)) {
-            throw new IllegalStateException(
-                    getLocationLogPrefix() + "Anchor name \"" + name + "\" used more than once");
+            LOGGER.warn("{}Anchor name \"{}\" used more than once", getLocationLogPrefix(), name);
         }
     }
 }

--- a/doxia-core/src/main/java/org/apache/maven/doxia/sink/impl/UniqueAnchorNamesValidator.java
+++ b/doxia-core/src/main/java/org/apache/maven/doxia/sink/impl/UniqueAnchorNamesValidator.java
@@ -27,7 +27,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Validates that each anchor name only appears once per document. Otherwise fails with an {@link IllegalStateException}.
+ * Validates that each anchor name only appears once per document. Otherwise logs a warning.
  */
 public class UniqueAnchorNamesValidator extends SinkWrapper {
 

--- a/doxia-core/src/main/java/org/apache/maven/doxia/sink/impl/UniqueAnchorNamesValidator.java
+++ b/doxia-core/src/main/java/org/apache/maven/doxia/sink/impl/UniqueAnchorNamesValidator.java
@@ -45,10 +45,6 @@ public class UniqueAnchorNamesValidator extends SinkWrapper {
         // assume that other anchor method signature calls this method under the hood in all relevant sink
         // implementations
         super.anchor(name, attributes);
-        enforceUniqueAnchor(name);
-    }
-
-    private void enforceUniqueAnchor(String name) {
         if (!usedAnchorNames.add(name)) {
             LOGGER.warn("{}Anchor name \"{}\" used more than once", getLocationLogPrefix(), name);
         }


### PR DESCRIPTION
Emit warning with location prefix
Pass document locator through SinkWrappers correctly