### PR TITLE
[DOXIA-749] Correctly indent and separate blocks inside list items

### DIFF
--- a/doxia-core/src/test/java/org/apache/maven/doxia/sink/impl/SinkEventElement.java
+++ b/doxia-core/src/test/java/org/apache/maven/doxia/sink/impl/SinkEventElement.java
@@ -35,6 +35,9 @@ public class SinkEventElement {
     /** The array of arguments to the sink method. */
     private final Object[] args;
 
+    /** The line number of the source which emitted the source (-1 if unknown) */
+    private final int lineNumber;
+
     /**
      * A SinkEventElement is characterized by the method name and associated array of arguments.
      *
@@ -42,11 +45,12 @@ public class SinkEventElement {
      * @param arguments The array of arguments to the sink method.
      *      For a no-arg element this may be null or an empty array.
      */
-    public SinkEventElement(String name, Object[] arguments) {
+    public SinkEventElement(String name, Object[] arguments, int lineNumber) {
         Objects.requireNonNull(name, "name cannot be null");
 
         this.methodName = name;
         this.args = arguments;
+        this.lineNumber = lineNumber;
     }
 
     /**
@@ -77,6 +81,10 @@ public class SinkEventElement {
         builder.append(this.getClass().getSimpleName()).append('[');
         builder.append("methodName: ").append(methodName).append(", ");
         builder.append("args: ").append(Arrays.deepToString(args));
+        if (lineNumber != -1) {
+            builder.append(", ");
+            builder.append("lineNumber: ").append(lineNumber);
+        }
         builder.append(']');
         return builder.toString();
     }

--- a/doxia-core/src/test/java/org/apache/maven/doxia/sink/impl/SinkEventTestingSink.java
+++ b/doxia-core/src/test/java/org/apache/maven/doxia/sink/impl/SinkEventTestingSink.java
@@ -553,6 +553,6 @@ public class SinkEventTestingSink extends AbstractSink {
      * @param arguments The array of arguments to the sink method.
      */
     private void addEvent(String string, Object[] arguments) {
-        events.add(new SinkEventElement(string, arguments));
+        events.add(new SinkEventElement(string, arguments, getDocumentLocator().getLineNumber()));
     }
 }

--- a/doxia-modules/doxia-module-markdown/src/main/java/org/apache/maven/doxia/module/markdown/MarkdownSink.java
+++ b/doxia-modules/doxia-module-markdown/src/main/java/org/apache/maven/doxia/module/markdown/MarkdownSink.java
@@ -873,9 +873,6 @@ public class MarkdownSink extends AbstractTextSink implements MarkdownMarkup {
 
     @Override
     public void text(String text, SinkEventAttributes attributes) {
-        if (text.equals("\n")) {
-            return;
-        }
         if (attributes != null) {
             inline(attributes);
         }
@@ -885,10 +882,13 @@ public class MarkdownSink extends AbstractTextSink implements MarkdownMarkup {
             LOGGER.warn("{}Ignoring unsupported table caption in Markdown", getLocationLogPrefix());
         } else {
             String unifiedText = currentContext.escape(unifyEOLs(text));
-            // each line must potentially be prefixed
-            String prefix = getLinePrefix();
-            if (prefix.length() > 0) {
-                unifiedText = unifiedText.replaceAll(EOL, EOL + prefix);
+            // ignore newlines only, because those are emitted often coming from linebreaks in HTML with no semantical
+            // meaning
+            if (!unifiedText.equals(EOL)) {
+                String prefix = getLinePrefix();
+                if (prefix.length() > 0) {
+                    unifiedText = unifiedText.replaceAll(EOL, EOL + prefix);
+                }
             }
             writeUnescaped(unifiedText);
         }

--- a/doxia-modules/doxia-module-markdown/src/test/java/org/apache/maven/doxia/module/markdown/MarkdownSinkTest.java
+++ b/doxia-modules/doxia-module-markdown/src/test/java/org/apache/maven/doxia/module/markdown/MarkdownSinkTest.java
@@ -371,6 +371,7 @@ public class MarkdownSinkTest extends AbstractSinkTest {
 
         final SinkEventTestingSink originalSink = new SinkEventTestingSink();
         parseFile(parser, "test", originalSink);
+        // strip empty lines from sink content
 
         // compare sink events from parsing original markdown with sink events from re-generated markdown
         try {
@@ -518,7 +519,7 @@ public class MarkdownSinkTest extends AbstractSinkTest {
             sink.listItem();
             sink.text("Before");
             sink.verbatim(SinkEventAttributeSet.SOURCE);
-            sink.text("codeline1\ncodeline2");
+            sink.text("codeline1" + EOL + "codeline2");
             sink.verbatim_();
             sink.text("After");
             sink.listItem_();


### PR DESCRIPTION
Block elements should be surrounded by blank lines inside list items to be compliant with more MD parsers