### PR TITLE
[DOXIA-757] Don't strip leading "#" from link names

### DIFF
--- a/doxia-modules/doxia-module-markdown/src/main/java/org/apache/maven/doxia/module/markdown/MarkdownSink.java
+++ b/doxia-modules/doxia-module-markdown/src/main/java/org/apache/maven/doxia/module/markdown/MarkdownSink.java
@@ -805,15 +805,13 @@ public class MarkdownSink extends AbstractTextSink implements MarkdownMarkup {
             // defer emitting link end markup until inline_() is called
             StringBuilder linkEndMarkup = new StringBuilder();
             linkEndMarkup.append(LINK_START_2_MARKUP);
-            linkEndMarkup.append(escapeMarkdown(linkName.startsWith("#") ? linkName.substring(1) : linkName));
+            linkEndMarkup.append(linkName);
             linkEndMarkup.append(LINK_END_MARKUP);
             Queue<String> endMarkups = new LinkedList<>(inlineStack.poll());
             endMarkups.add(linkEndMarkup.toString());
             inlineStack.add(endMarkups);
         } else {
-            writeUnescaped(LINK_START_2_MARKUP);
-            text(linkName.startsWith("#") ? linkName.substring(1) : linkName);
-            writeUnescaped(LINK_END_MARKUP);
+            writeUnescaped(LINK_START_2_MARKUP + linkName + LINK_END_MARKUP);
         }
         linkName = null;
     }

--- a/doxia-modules/doxia-module-markdown/src/test/java/org/apache/maven/doxia/module/markdown/MarkdownSinkTest.java
+++ b/doxia-modules/doxia-module-markdown/src/test/java/org/apache/maven/doxia/module/markdown/MarkdownSinkTest.java
@@ -250,11 +250,10 @@ public class MarkdownSinkTest extends AbstractSinkTest {
 
     /** {@inheritDoc} */
     protected String getLinkBlock(String link, String text) {
-        String lnk = link.startsWith("#") ? link.substring(1) : link;
         return MarkdownMarkup.LINK_START_1_MARKUP
                 + text
                 + MarkdownMarkup.LINK_START_2_MARKUP
-                + lnk
+                + link
                 + MarkdownMarkup.LINK_END_MARKUP;
     }
 
@@ -527,7 +526,7 @@ public class MarkdownSinkTest extends AbstractSinkTest {
             sink.inline_();
         }
         // heading must be on a new line
-        String expected = "[`label`](http://example\\.com)";
+        String expected = "[`label`](http://example.com)";
         assertEquals(expected, getSinkContent(), "Wrong link on code!");
     }
 


### PR DESCRIPTION
Markdown is fundamentally different with anchor links from APT. Never try to escape link names as according to Sink API those always must be valid URIs.