### PR TITLE
(doc) Fix missing references in JavaDocs

### DIFF
--- a/doxia-core/src/main/java/org/apache/maven/doxia/macro/MacroExecutor.java
+++ b/doxia-core/src/main/java/org/apache/maven/doxia/macro/MacroExecutor.java
@@ -19,6 +19,7 @@
 package org.apache.maven.doxia.macro;
 
 import org.apache.maven.doxia.macro.manager.MacroNotFoundException;
+import org.apache.maven.doxia.parser.Parser;
 import org.apache.maven.doxia.sink.Sink;
 
 /**
@@ -32,8 +33,8 @@ public interface MacroExecutor {
      * @param macroId an id to lookup the macro
      * @param request the corresponding MacroRequest
      * @param sink the sink to receive the events
-     * @throws org.apache.maven.doxia.macro.MacroExecutionException if an error occurred during execution
-     * @throws org.apache.maven.doxia.macro.manager.MacroNotFoundException if the macro could not be found
+     * @throws MacroExecutionException if an error occurred during execution
+     * @throws MacroNotFoundException if the macro could not be found
      */
     void executeMacro(String macroId, MacroRequest request, Sink sink)
             throws MacroExecutionException, MacroNotFoundException;

--- a/doxia-core/src/test/java/org/apache/maven/doxia/sink/impl/AbstractSinkTest.java
+++ b/doxia-core/src/test/java/org/apache/maven/doxia/sink/impl/AbstractSinkTest.java
@@ -267,7 +267,7 @@ public abstract class AbstractSinkTest extends AbstractModuleTest {
      * Checks that the sequence <code>[sectionTitle(), text(title),
      * sectionTitle_()]</code>, invoked on the current sink, produces
      * the same result as
-     * {@link #getTextBlock(title) as the sectionTitle methods should be no-ops.
+     * {@link #getTextBlock getTextBlock}(title) as the sectionTitle methods should be no-ops.
      */
     @Test
     public void testSectionTitle() {
@@ -859,7 +859,7 @@ public abstract class AbstractSinkTest extends AbstractModuleTest {
     /**
      * Checks that the sequence <code>[verbatim(null), text(text),
      * verbatim_()]</code>, invoked on the current sink, produces the
-     * same result as {@link #getVerbatimeBlock getVerbatimBlock}(text).
+     * same result as {@link #getVerbatimBlock getVerbatimeBlock}(text).
      */
     @Test
     public void testVerbatim() {


### PR DESCRIPTION
Fixes some broken links in the JavaDoc.

---

The `Sink.java` file also shows some broken links, but I don't know on what methods those should be:

![image](https://github.com/user-attachments/assets/be7057ec-2273-4e29-9e03-48a6179e34de)
