### PR TITLE
Optionally leave fragments of internal links untouched

### DIFF
--- a/doxia-core/src/main/java/org/apache/maven/doxia/parser/Xhtml5BaseParser.java
+++ b/doxia-core/src/main/java/org/apache/maven/doxia/parser/Xhtml5BaseParser.java
@@ -813,7 +813,9 @@ public class Xhtml5BaseParser extends AbstractXmlParser implements HtmlMarkup {
 
         if (href != null) {
             int hashIndex = href.indexOf('#');
-            if (hashIndex != -1 && !DoxiaUtils.isExternalLink(href)) {
+            if (hashIndex != -1
+                    && !DoxiaUtils.isExternalLink(href)
+                    && !"external".equals(attribs.getAttribute(Attribute.REL.toString()))) {
                 String hash = href.substring(hashIndex + 1);
 
                 if (!DoxiaUtils.isValidId(hash)) {

--- a/doxia-core/src/test/java/org/apache/maven/doxia/parser/Xhtml5BaseParserTest.java
+++ b/doxia-core/src/test/java/org/apache/maven/doxia/parser/Xhtml5BaseParserTest.java
@@ -841,6 +841,35 @@ class Xhtml5BaseParserTest extends AbstractParserTest {
         assertEquals("division_", element.getName());
     }
 
+    @Test
+    void anchorLinkWithExternalRel() throws Exception {
+        // although the fragment is not a valid doxia id it should be used as is, because the rel="external" indicates
+        // that this is an external link
+        String text = "<a href=\"index.html#1invalid\" rel=\"external\"></a>";
+
+        parser.parse(text, sink);
+        Iterator<SinkEventElement> it = sink.getEventList().iterator();
+
+        SinkEventElement element = it.next();
+
+        assertEquals("link", element.getName());
+        assertEquals("index.html#1invalid", element.getArgs()[0]);
+        assertEquals("external", ((SinkEventAttributeSet) element.getArgs()[1]).getAttribute("rel"));
+        assertEquals("link_", it.next().getName());
+    }
+
+    @Test
+    void anchorWithName() throws ParseException {
+        String text = "<a name=\"test\"></a>";
+
+        parser.parse(text, sink);
+
+        Iterator<SinkEventElement> it = sink.getEventList().iterator();
+        // first attribute is the id, second is all given attributes
+        assertSinkEquals(it.next(), "anchor", "test", new SinkEventAttributeSet("name", "test"));
+        assertSinkEquals(it, "anchor_");
+    }
+
     /**
      * Test entities in attributes.
      *
@@ -941,17 +970,5 @@ class Xhtml5BaseParserTest extends AbstractParserTest {
     @Override
     protected String getVerbatimCodeSource() {
         return "<pre><code>&lt;&gt;{}=#*</code></pre>";
-    }
-
-    @Test
-    void anchorWithName() throws ParseException {
-        String text = "<a name=\"test\"></a>";
-
-        parser.parse(text, sink);
-
-        Iterator<SinkEventElement> it = sink.getEventList().iterator();
-        // first attribute is the id, second is all given attributes
-        assertSinkEquals(it.next(), "anchor", "test", new SinkEventAttributeSet("name", "test"));
-        assertSinkEquals(it, "anchor_");
     }
 }

--- a/doxia-modules/doxia-module-markdown/src/site/apt/index.apt
+++ b/doxia-modules/doxia-module-markdown/src/site/apt/index.apt
@@ -82,7 +82,8 @@ doxia-module-markdown
   
 * Parser
 
-  The parser will first convert Markdown into HTML and then parse the HTML into Doxia Sink API methods calls.
+  The parser will first convert Markdown into HTML and then parse the HTML into Doxia Sink API methods calls leveraging the 
+  {{{../doxia-module-xhtml5/index.html}XHTML5 parser}}.
 
 * References
 

--- a/doxia-modules/doxia-module-markdown/src/test/java/org/apache/maven/doxia/module/markdown/MarkdownParserTest.java
+++ b/doxia-modules/doxia-module-markdown/src/test/java/org/apache/maven/doxia/module/markdown/MarkdownParserTest.java
@@ -901,4 +901,31 @@ class MarkdownParserTest extends AbstractParserTest {
         assertSinkStartsWith(eventIterator, "text", "inline_", "paragraph_");
         assertEventSuffix(eventIterator);
     }
+
+    @Test
+    void relativeLinkWithAnchorInvalidDoxiaId() throws ParseException {
+        Iterator<SinkEventElement> eventIterator = parseSourceToEventTestingSink("[Test URL](test.html#anchor\\(\\))")
+                .getEventList()
+                .iterator();
+        assertEventPrefix(eventIterator);
+        assertSinkStartsWith(eventIterator, "paragraph");
+        SinkEventElement linkEvent = eventIterator.next();
+        assertEquals("link", linkEvent.getName());
+        // converted to valid doxia id (through DoxiaUtils.encodeId)
+        assertEquals("test.html#anchor.28.29", linkEvent.getArgs()[0]);
+    }
+
+    @Test
+    void relativeLinkWithAnchorInvalidDoxiaIdAndRelExternal() throws ParseException {
+        Iterator<SinkEventElement> eventIterator = parseSourceToEventTestingSink(
+                        "<a href=\"test.html#anchor()\" rel=\"external\">Test URL</a>")
+                .getEventList()
+                .iterator();
+        assertEventPrefix(eventIterator);
+        assertSinkStartsWith(eventIterator, "paragraph");
+        SinkEventElement linkEvent = eventIterator.next();
+        assertEquals("link", linkEvent.getName());
+        // left untouched because of rel="external" despite being an invalid doxia id
+        assertEquals("test.html#anchor()", linkEvent.getArgs()[0]);
+    }
 }

--- a/doxia-modules/doxia-module-xhtml5/src/site/markdown/index.md
+++ b/doxia-modules/doxia-module-xhtml5/src/site/markdown/index.md
@@ -1,0 +1,33 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+# Doxia XHTML5 Module
+
+This parser and sink digests and emits sources compliant with the [XML syntax of HTML5](https://html.spec.whatwg.org/#the-xhtml-syntax).
+
+## Special handling of anchors
+
+Anchor ids/names need to follow a strict syntax in Doxia, therefore both anchor names (`<a name="...">`) as well as internal link targets (`<a href="..."`) are automatically adjusted to comply with that syntax. Further details in [DoxiaUtils.encodeId(...)](../../doxia-core/apidocs/org/apache/maven/doxia/util/DoxiaUtils.html#encodeId-java.lang.String-).
+
+In order to leave internal link targets (i.e. ones not starting with a scheme) unprocessed use attribute `rel` with value `external` like this
+
+```
+<a href="testpage#specialanchor()" rel="external">...</a>
+```
+
+Otherwise the fragment `specialanchor()` would be converted as `(` and `)` are not valid in Doxia IDs.


### PR DESCRIPTION
Evaluate "rel" attribute on "a" elements. If set to "external" the fragment is not
normalized to a Doxia ID.

This is particularly helpful to link out to (internal) javadoc, where fragments contain "(" and ")" characters which are invalid in Doxia IDs.

This closes #1029

Following this checklist to help us incorporate your
contribution quickly and easily:

- [ ] Your pull request should address just one issue, without pulling in other changes.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
  Note that commits might be squashed by a maintainer on merge.
- [ ] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied.
  This may not always be possible but is a best-practice.
- [ ] Run `mvn verify` to make sure basic checks pass.
  A more thorough check will be performed on your pull request automatically.
- [ ] You have run the integration tests successfully (`mvn -Prun-its verify`).

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [ ] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
