### PR TITLE
Let APT macro blocks end at the last brace on the line

### DIFF
--- a/doxia-modules/doxia-module-apt/src/main/java/org/apache/maven/doxia/module/apt/AptParser.java
+++ b/doxia-modules/doxia-module-apt/src/main/java/org/apache/maven/doxia/module/apt/AptParser.java
@@ -2371,7 +2371,10 @@ public class AptParser extends AbstractTextParser implements AptMarkup {
             }
 
             final int start = text.indexOf('{');
-            final int end = text.indexOf('}');
+            // the macro block always ends with the closing brace, so look for the last one:
+            // parameter values may contain braces themselves (e.g. unresolved Velocity references
+            // such as ${project.build.directory} when the raw source of a *.apt.vm file is parsed)
+            final int end = text.lastIndexOf('}');
 
             String s = text.substring(start + 1, end);
 

--- a/doxia-modules/doxia-module-apt/src/test/java/org/apache/maven/doxia/module/apt/AptParserTest.java
+++ b/doxia-modules/doxia-module-apt/src/test/java/org/apache/maven/doxia/module/apt/AptParserTest.java
@@ -25,6 +25,8 @@ import java.io.Reader;
 import java.io.StringWriter;
 import java.io.Writer;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.Map;
 
 import org.apache.maven.doxia.parser.AbstractParser;
 import org.apache.maven.doxia.parser.AbstractParserTest;
@@ -73,6 +75,29 @@ class AptParserTest extends AbstractParserTest {
         String macro = parseFileToAptSink("test/macro");
 
         assertTrue(macro.contains("<modelVersion\\>4.0.0\\</modelVersion\\>"));
+    }
+
+    /**
+     * A macro parameter value may contain braces itself, for example an unresolved Velocity
+     * reference when the raw source of a {@code *.apt.vm} file is parsed. The macro block ends
+     * with the last brace on the line, not the first one.
+     */
+    @Test
+    void macroWithBracesInParameterValue() throws Exception {
+        Map<String, Object> parameters = new LinkedHashMap<>();
+
+        AbstractParser parser = createParser();
+        parser.setMacroExecutor((id, request, sink) -> {
+            assertEquals("snippet", id);
+            parameters.putAll(request.getParameters());
+        });
+
+        try (Reader reader = getTestReader("test/macro-braces-in-parameter")) {
+            parser.parse(reader, new SinkEventTestingSink());
+        }
+
+        assertEquals("superpom", parameters.get("id"));
+        assertEquals("${project.build.directory}/test-classes/pom-4.0.0.xml", parameters.get("file"));
     }
 
     @Test

--- a/doxia-modules/doxia-module-apt/src/test/resources/test/macro-braces-in-parameter.apt
+++ b/doxia-modules/doxia-module-apt/src/test/resources/test/macro-braces-in-parameter.apt
@@ -1,0 +1,7 @@
+ -----
+ Braces in macro parameters
+ -----
+
+Braces in macro parameters
+
+%{snippet|id=superpom|file=${project.build.directory}/test-classes/pom-4.0.0.xml}


### PR DESCRIPTION
MacroBlock.traverse() located the end of the macro with indexOf('}'),
which is the *first* closing brace. A parameter value containing braces
therefore truncated the macro, silently dropping the rest of the value.

This shows up when the raw source of a *.apt.vm file is parsed, where
Velocity references are still unresolved:

  %{snippet|file=${project.build.directory}/test-classes/resolve.txt}

parsed as file=${project.build.directory}, dropping the path. In a normal
site build Velocity runs first so no brace remains, but doxia-converter
parses the unprocessed source and lost the parameter.

The macro block always ends with the closing brace, so use lastIndexOf.


Part of the wider migration tracked in
https://github.com/apache/maven-doxia-converter/issues/139
