### PR TITLE
Stop over-escaping text in the Markdown sink

### DIFF
--- a/doxia-modules/doxia-module-markdown/src/main/java/org/apache/maven/doxia/module/markdown/LastTwoLinesAwareWriter.java
+++ b/doxia-modules/doxia-module-markdown/src/main/java/org/apache/maven/doxia/module/markdown/LastTwoLinesAwareWriter.java
@@ -99,4 +99,30 @@ public class LastTwoLinesAwareWriter extends Writer {
     public boolean isAfterDigit() {
         return currentLine.length() > 1 && Character.isDigit(currentLine.charAt(currentLine.length() - 1));
     }
+
+    /**
+     * @return {@code true} if the current line consists of optional leading whitespace followed by
+     * at least one digit and nothing else, i.e. a subsequent {@code .} would turn it into the
+     * marker of an ordered list item
+     */
+    public boolean isAfterOnlyLeadingDigits() {
+        return isOnlyLeadingDigits(currentLine);
+    }
+
+    /**
+     * @param line the line (fragment) to check
+     * @return {@code true} if {@code line} consists of optional leading whitespace followed by
+     * at least one digit and nothing else
+     */
+    static boolean isOnlyLeadingDigits(CharSequence line) {
+        int index = 0;
+        while (index < line.length() && (line.charAt(index) == ' ' || line.charAt(index) == '\t')) {
+            index++;
+        }
+        final int firstDigit = index;
+        while (index < line.length() && Character.isDigit(line.charAt(index))) {
+            index++;
+        }
+        return index > firstDigit && index == line.length();
+    }
 }

--- a/doxia-modules/doxia-module-markdown/src/main/java/org/apache/maven/doxia/module/markdown/MarkdownSink.java
+++ b/doxia-modules/doxia-module-markdown/src/main/java/org/apache/maven/doxia/module/markdown/MarkdownSink.java
@@ -36,6 +36,7 @@ import org.apache.maven.doxia.sink.SinkEventAttributes;
 import org.apache.maven.doxia.sink.impl.SinkEventAttributeSet;
 import org.apache.maven.doxia.sink.impl.Xhtml5BaseSink;
 import org.apache.maven.doxia.util.DoxiaStringUtils;
+import org.apache.maven.doxia.util.DoxiaUtils;
 import org.apache.maven.doxia.util.HtmlTools;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -404,6 +405,25 @@ public class MarkdownSink extends Xhtml5BaseSink implements MarkdownMarkup {
     // ----------------------------------------------------------------------
     // Public protected methods
     // ----------------------------------------------------------------------
+
+    /**
+     * A link destination must not contain a space: everything from the space on is read as the
+     * link title instead, so {@code [text](#My Anchor)} does not resolve. An in-page anchor
+     * therefore gets the same encoding the anchor definition receives, and any other destination
+     * has its spaces percent-encoded.
+     *
+     * @param destination the link destination, may be null
+     * @return the destination, safe to write into a Markdown inline link
+     */
+    private static String encodeLinkDestination(String destination) {
+        if (destination == null || destination.indexOf(' ') < 0) {
+            return destination;
+        }
+        if (destination.charAt(0) == '#') {
+            return "#" + DoxiaUtils.encodeId(destination.substring(1));
+        }
+        return destination.replace(" ", "%20");
+    }
 
     protected static MarkdownSink newInstance(Writer writer) {
         BufferingStackWriter bufferingStackWriter = new BufferingStackWriter(writer);
@@ -1141,13 +1161,13 @@ public class MarkdownSink extends Xhtml5BaseSink implements MarkdownMarkup {
                 // defer emitting link end markup until inline_() is called
                 StringBuilder linkEndMarkup = new StringBuilder();
                 linkEndMarkup.append(LINK_START_2_MARKUP);
-                linkEndMarkup.append(linkName);
+                linkEndMarkup.append(encodeLinkDestination(linkName));
                 linkEndMarkup.append(LINK_END_MARKUP);
                 Queue<String> endMarkups = new LinkedList<>(inlineStack.poll());
                 endMarkups.add(linkEndMarkup.toString());
                 inlineStack.add(endMarkups);
             } else {
-                write(LINK_START_2_MARKUP + linkName + LINK_END_MARKUP);
+                write(LINK_START_2_MARKUP + encodeLinkDestination(linkName) + LINK_END_MARKUP);
             }
             linkName = null;
         }

--- a/doxia-modules/doxia-module-markdown/src/main/java/org/apache/maven/doxia/module/markdown/MarkdownSink.java
+++ b/doxia-modules/doxia-module-markdown/src/main/java/org/apache/maven/doxia/module/markdown/MarkdownSink.java
@@ -280,7 +280,7 @@ public class MarkdownSink extends Xhtml5BaseSink implements MarkdownMarkup {
             if (text == null) {
                 return "";
             }
-            text = escapeHtml(writer, text); // assume UTF-8 output, i.e. only use the mandatory XML entities
+            text = escapeHtmlForMarkdown(text); // assume UTF-8 output, i.e. only use the mandatory XML entities
             int length = text.length();
             StringBuilder buffer = new StringBuilder(length);
 
@@ -292,8 +292,6 @@ public class MarkdownSink extends Xhtml5BaseSink implements MarkdownMarkup {
                     case '`':
                     case '[':
                     case ']':
-                    case '(':
-                    case ')':
                     case '!':
                         // always escape the previous characters as potentially everywhere relevant
                         buffer.append(escapeMarkdown(c));
@@ -317,7 +315,7 @@ public class MarkdownSink extends Xhtml5BaseSink implements MarkdownMarkup {
                         }
                         break;
                     case '.':
-                        if (isAfterDigit(buffer, writer)) {
+                        if (isAfterOnlyLeadingDigits(buffer, writer)) {
                             buffer.append(escapeMarkdown(c));
                         } else {
                             buffer.append(c);
@@ -330,11 +328,16 @@ public class MarkdownSink extends Xhtml5BaseSink implements MarkdownMarkup {
             return buffer.toString();
         }
 
-        private static boolean isAfterDigit(StringBuilder buffer, LastTwoLinesAwareWriter writer) {
+        /**
+         * A {@code .} only needs escaping when it would turn leading digits into the marker of an
+         * ordered list item, i.e. when nothing but whitespace and digits precede it on the line.
+         * Elsewhere (as in version numbers such as {@code 1.6}) it is an ordinary character.
+         */
+        private static boolean isAfterOnlyLeadingDigits(StringBuilder buffer, LastTwoLinesAwareWriter writer) {
             if (buffer.length() > 0) {
-                return Character.isDigit(buffer.charAt(buffer.length() - 1));
+                return writer.isInBlankLine() && LastTwoLinesAwareWriter.isOnlyLeadingDigits(buffer);
             } else {
-                return writer.isAfterDigit();
+                return writer.isAfterOnlyLeadingDigits();
             }
         }
 
@@ -351,6 +354,40 @@ public class MarkdownSink extends Xhtml5BaseSink implements MarkdownMarkup {
 
         private String escapeHtml(LastTwoLinesAwareWriter writer, String text) {
             return HtmlTools.escapeHTML(text, true);
+        }
+
+        /**
+         * Escapes only those characters which would otherwise be interpreted as raw HTML inside a
+         * Markdown document. Unlike {@link HtmlTools#escapeHTML(String, boolean)} this leaves
+         * {@code "} and {@code '} alone: Markdown is not XML, both are ordinary characters there,
+         * and turning them into {@code &quot;}/{@code &apos;} only makes the source unreadable.
+         *
+         * @param text the string to escape, may be null
+         * @return the escaped text, "" if null String input
+         */
+        private static String escapeHtmlForMarkdown(String text) {
+            if (text == null) {
+                return "";
+            }
+            int length = text.length();
+            StringBuilder buffer = new StringBuilder(length);
+            for (int i = 0; i < length; ++i) {
+                char c = text.charAt(i);
+                switch (c) {
+                    case '<':
+                        buffer.append("&lt;");
+                        break;
+                    case '>':
+                        buffer.append("&gt;");
+                        break;
+                    case '&':
+                        buffer.append("&amp;");
+                        break;
+                    default:
+                        buffer.append(c);
+                }
+            }
+            return buffer.toString();
         }
 
         /**

--- a/doxia-modules/doxia-module-markdown/src/test/java/org/apache/maven/doxia/module/markdown/MarkdownSinkTest.java
+++ b/doxia-modules/doxia-module-markdown/src/test/java/org/apache/maven/doxia/module/markdown/MarkdownSinkTest.java
@@ -669,7 +669,7 @@ class MarkdownSinkTest extends AbstractSinkTest {
                 + "|---|---|---|" + EOL
                 + "|[iText](../modules/index.html#iText)|iText PDF Library|[`doxia-module-itext`](../doxia/doxia-modules/doxia-module-itext/)|"
                 + EOL
-                + "|[FO](../modules/index.html#FO)<sup>*</sup>|XSL formatting objects \\(XSL-FO\\)|[`doxia-module-fo`](../doxia/doxia-modules/doxia-module-fo/)|"
+                + "|[FO](../modules/index.html#FO)<sup>*</sup>|XSL formatting objects (XSL-FO)|[`doxia-module-fo`](../doxia/doxia-modules/doxia-module-fo/)|"
                 + EOL
                 + "|[LaTeX](../modules/index.html#LaTeX)|LaTeX typesetting system|[`doxia-module-latex`](../doxia/doxia-modules/doxia-module-latex/)|"
                 + EOL

--- a/doxia-modules/doxia-module-markdown/src/test/java/org/apache/maven/doxia/module/markdown/MarkdownSinkTest.java
+++ b/doxia-modules/doxia-module-markdown/src/test/java/org/apache/maven/doxia/module/markdown/MarkdownSinkTest.java
@@ -321,6 +321,32 @@ class MarkdownSinkTest extends AbstractSinkTest {
         return getCommentBlock(comment) + EOL + EOL + getParagraphBlock(paragraph); // paragraph separated by blank line
     }
 
+    /**
+     * A space ends the destination of a Markdown inline link, so an APT anchor reference such as
+     * {@code {{{#Identity Mapper}Identity Mapper}}} must not be written through unchanged.
+     */
+    @Test
+    void linkDestinationWithSpace() {
+        Writer writer = new StringWriter();
+        try (Sink sink = createSink(writer)) {
+            sink.link("#Identity Mapper");
+            sink.text("Identity Mapper");
+            sink.link_();
+        }
+        assertEquals("[Identity Mapper](#Identity_Mapper)", writer.toString().trim());
+    }
+
+    @Test
+    void externalLinkDestinationWithSpace() {
+        Writer writer = new StringWriter();
+        try (Sink sink = createSink(writer)) {
+            sink.link("https://example.org/a b.html");
+            sink.text("a b");
+            sink.link_();
+        }
+        assertEquals("[a b](https://example.org/a%20b.html)", writer.toString().trim());
+    }
+
     @Test
     void multipleAuthors() {
         final Sink sink = getSink();


### PR DESCRIPTION
Three cases where the sink escaped characters that are not special in
Markdown, making generated documents noisy and hard to hand-edit:

- " and ' were turned into &quot; and &apos;. Markdown is not XML; both
  are ordinary characters there. Only <, > and & still get escaped, so
  text is never mistaken for raw HTML.
- ( and ) were escaped everywhere. They are only special inside a link
  destination, and destinations are written without going through the
  text escaping, so 'JDK (i.e. Java 6)' no longer becomes 'JDK \(i.e.
  Java 6\)'.
- . was escaped after any digit, so a version such as 1.6 came out as
  1\.6. It only needs escaping when it would turn leading digits into an
  ordered list marker, i.e. when only whitespace and digits precede it.

Adjusted the one affected expectation in MarkdownSinkTest.

A second change in the same area: a space ends the destination of a Markdown
inline link and starts the optional title, so a destination carrying one does
not resolve. APT allows spaces in both anchors and URLs, so converting a
document like

    The {{{#Identity Mapper}Identity Mapper}}

produced [Identity Mapper](#Identity Mapper), which links nowhere. An in-page
anchor now gets the same encoding an anchor definition receives, which is also
what the HTML renderer applies to the anchor it points at, and any other
destination has its spaces percent-encoded.

Part of the wider migration tracked in
https://github.com/apache/maven-doxia-converter/issues/139
