### PR TITLE
Drop backslash escapes that Markdown does not need

### DIFF
--- a/doxia-core/src/site/markdown/using-randomaccesssink.md
+++ b/doxia-core/src/site/markdown/using-randomaccesssink.md
@@ -24,7 +24,7 @@ date: 2011-01-07
 
 # Using the RandomAccessSink
 
-The RandomAccessSink is a Sink with the ability to add hooks. To demonstrate its usage we can have a look at a FML \(FAQ Markup Language\)-page. The simple structure of such a page can be like:
+The RandomAccessSink is a Sink with the ability to add hooks. To demonstrate its usage we can have a look at a FML (FAQ Markup Language)-page. The simple structure of such a page can be like:
 
 ```unknown
   <faq id="1">

--- a/doxia-modules/doxia-module-markdown/src/site/markdown/index.md
+++ b/doxia-modules/doxia-module-markdown/src/site/markdown/index.md
@@ -26,7 +26,7 @@ date: 2017-03-04
 
 # doxia-module-markdown
 
-Markdown is a popular lightweight markup language, easy to read and easy to write. It is supported by a large panel of websites, text editors/IDEs and converter tools. Markdown format is supported both as source \(parser\) and destination \(sink\), the latter only since version 1\.12\.0\.
+Markdown is a popular lightweight markup language, easy to read and easy to write. It is supported by a large panel of websites, text editors/IDEs and converter tools. Markdown format is supported both as source (parser) and destination (sink), the latter only since version 1\.12\.0\.
 
 ## Metadata
 
@@ -48,7 +48,7 @@ Currently only the following metadata elements are supported:
 
 As the original Markdown specification is simple many extensions have been created to add features to the original Markdown format. The following extensions are supported by this module:
 
-### GFM \(GitHub Flavored Markdown\) extensions
+### GFM (GitHub Flavored Markdown) extensions
 
 GitHub specified [extensions](https://github.github.com/gfm) to the original Markdown and CommonMark format, which are now widely used. Some of these extensions are also supported by this module, namely
 


### PR DESCRIPTION
Pages converted from APT with an older `doxia-converter` carry a backslash in front of
punctuation that is not markup where it stands, for example `maven\-source\-plugin`,
`\(default\)` and `required\.`. The backslash renders as nothing; it only makes the source
harder to read and to edit, which was the point of moving to Markdown.

Only positions where the bare character can never be markup are touched: a hyphen,
underscore or asterisk between two word characters, a parenthesis, a full stop that
does not follow a digit, and an exclamation mark not followed by `[`.

Left alone deliberately:

* angle brackets, since `<escapeString>` really would be read as an HTML tag
* a full stop after a digit, so an ordered list marker cannot appear by accident
* a run of dots, because bare `...` is rendered as a single ellipsis character
* code spans, fenced blocks and link destinations

Verified by building the site before and after: every generated page is identical in
its visible text and in every link target.