### PR TITLE
Document how Markdown code blocks reach the Sink

### DIFF
--- a/doxia-modules/doxia-module-markdown/src/main/java/org/apache/maven/doxia/module/markdown/MarkdownParser.java
+++ b/doxia-modules/doxia-module-markdown/src/main/java/org/apache/maven/doxia/module/markdown/MarkdownParser.java
@@ -331,10 +331,10 @@ public class MarkdownParser extends AbstractTextParser implements TextMarkup {
      * <ul>
      * <li> DIV elements are translated as Unknown Sink events
      * </ul>
-     * PRE elements need to be "source" because the Xhtml5Sink will surround the
-     * corresponding verbatim() Sink event with a DIV element with class="source",
-     * which is how most Maven Skin (incl. Fluido) recognize a block of code, which
-     * needs to be highlighted accordingly.
+     * A code block does not carry the {@code source} decoration on its {@code verbatim} event, unlike the APT
+     * and XDoc modules. The language of a fenced code block has to be conveyed anyway, and the {@code inline}
+     * event emitted for the nested CODE element carries both that and the code semantics, so the decoration
+     * would add nothing. See {@code fencedCodeBlockSinkEvent} in the module tests for the exact events.
      */
     @Named
     public static class MarkdownHtmlParser extends Xhtml5Parser {

--- a/doxia-modules/doxia-module-markdown/src/site/markdown/index.md
+++ b/doxia-modules/doxia-module-markdown/src/site/markdown/index.md
@@ -66,6 +66,18 @@ GitHub specified [extensions](https://github.github.com/gfm) to the original Mar
 
 The parser will first convert Markdown into HTML, convert to XHTML via [JSoup](https://jsoup.org/) and then parse the XHTML into Doxia Sink API methods calls leveraging the [XHTML5 parser](../doxia-module-xhtml5/index.html).
 
+## Code blocks
+
+Both indented and fenced code blocks become a `verbatim` Sink event containing an `inline` event with the `code` semantics, rendered as `<pre><code>`.
+
+The info string of a fenced code block, if there is one, is passed on as a class on that inline event, so
+
+<pre>```java</pre>
+
+produces `<pre><code class="language-java">`, which is the convention syntax highlighters look for. A fenced block without an info string, and an indented block, produce `<pre><code class="nohighlight nocode">` instead, which is how [highlight.js](https://highlightjs.readthedocs.io/en/latest/readme.html#ignoring-a-code-block) and [code-prettify](https://github.com/googlearchive/code-prettify#how-do-i-prevent-a-portion-of-markup-from-being-marked-as-code) are told to leave a block alone.
+
+Note that this differs from the APT and XDoc modules, where `+--` and `<source>` mark a code block by putting the `source` decoration on the `verbatim` event itself. Markdown carries the same information on the nested inline event instead, because it has a language to convey as well.
+
 ## References
 
 - [Markdown project website](http://daringfireball.net/projects/markdown)


### PR DESCRIPTION
Part of #876 (DOXIA-762), which asks for the Markdown side of code highlighting to be written down somewhere. The module page currently says nothing about code blocks at all.

Two things here.

**The module page gains a "Code blocks" section.** Verified against the current parser rather than inferred:

| Markdown | inline event class | rendered |
| --- | --- | --- |
| ` ```java ` | `language-java` | `<pre><code class="language-java">` |
| ` ``` ` with no info string | `nohighlight nocode` | `<pre><code class="nohighlight nocode">` |
| indented block | `nohighlight nocode` | `<pre><code class="nohighlight nocode">` |

The first row is asserted by `fencedCodeBlockSinkEvent` in the module's own tests. I confirmed the indented case by dumping the events for `code.md`, since only the fenced case was covered. The two odd class names come from `FENCED_CODE_NO_LANGUAGE_CLASS` and are the opt-out markers for highlight.js and code-prettify, which is worth stating since they look arbitrary otherwise.

**The `MarkdownHtmlParser` javadoc is corrected.** It currently says:

> PRE elements need to be "source" because the Xhtml5Sink will surround the corresponding verbatim() Sink event with a DIV element with class="source", which is how most Maven Skin (incl. Fluido) recognize a block of code

That is no longer what happens, and the module's own test comment says as much: *"instead of using a decoration tag on the verbatim event an additional inline event is used"*. The `verbatim` event carries no attributes; the nested `inline` event carries the semantics and the language. Leaving the old description in place is worse than having none, since it points at a mechanism that is not there.

The replacement also records why Markdown differs from APT and XDoc, where `+--` and `<source>` put the `source` decoration on the `verbatim` event: Markdown has a language to convey as well, and the inline event already carries it, so the decoration would add nothing.

On its own this does not cover all of #876. The APT half is apache/maven-doxia-site#70, and whether the four parsers should converge on one representation is a separate question I have deliberately not touched here.
