### PR TITLE
Restore the plain form of the ASF licence header

### DIFF
--- a/doxia-core/src/site/markdown/using-randomaccesssink.md
+++ b/doxia-core/src/site/markdown/using-randomaccesssink.md
@@ -5,22 +5,24 @@ author:
 date: 2011-01-07
 ---
 
-<!-- Licensed to the Apache Software Foundation (ASF) under one-->
-<!-- or more contributor license agreements.  See the NOTICE file-->
-<!-- distributed with this work for additional information-->
-<!-- regarding copyright ownership.  The ASF licenses this file-->
-<!-- to you under the Apache License, Version 2.0 (the-->
-<!-- "License"); you may not use this file except in compliance-->
-<!-- with the License.  You may obtain a copy of the License at-->
-<!---->
-<!--   http://www.apache.org/licenses/LICENSE-2.0-->
-<!---->
-<!-- Unless required by applicable law or agreed to in writing,-->
-<!-- software distributed under the License is distributed on an-->
-<!-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY-->
-<!-- KIND, either express or implied.  See the License for the-->
-<!-- specific language governing permissions and limitations-->
-<!-- under the License.-->
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
 
 # Using the RandomAccessSink
 

--- a/doxia-modules/doxia-module-fml/src/site/markdown/using-fml-xsd.md
+++ b/doxia-modules/doxia-module-fml/src/site/markdown/using-fml-xsd.md
@@ -5,22 +5,24 @@ author:
 date: 2009-06-15
 ---
 
-<!-- Licensed to the Apache Software Foundation (ASF) under one-->
-<!-- or more contributor license agreements.  See the NOTICE file-->
-<!-- distributed with this work for additional information-->
-<!-- regarding copyright ownership.  The ASF licenses this file-->
-<!-- to you under the Apache License, Version 2.0 (the-->
-<!-- "License"); you may not use this file except in compliance-->
-<!-- with the License.  You may obtain a copy of the License at-->
-<!---->
-<!--   http://www.apache.org/licenses/LICENSE-2.0-->
-<!---->
-<!-- Unless required by applicable law or agreed to in writing,-->
-<!-- software distributed under the License is distributed on an-->
-<!-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY-->
-<!-- KIND, either express or implied.  See the License for the-->
-<!-- specific language governing permissions and limitations-->
-<!-- under the License.-->
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
 
 # Using Schema FML 1\.0\.1
 

--- a/doxia-modules/doxia-module-markdown/src/site/markdown/index.md
+++ b/doxia-modules/doxia-module-markdown/src/site/markdown/index.md
@@ -5,24 +5,24 @@ author:
 date: 2017-03-04
 ---
 
-<!-- Licensed to the Apache Software Foundation (ASF) under one-->
-<!-- or more contributor license agreements.  See the NOTICE file-->
-<!-- distributed with this work for additional information-->
-<!-- regarding copyright ownership.  The ASF licenses this file-->
-<!-- to you under the Apache License, Version 2.0 (the-->
-<!-- "License"); you may not use this file except in compliance-->
-<!-- with the License.  You may obtain a copy of the License at-->
-<!---->
-<!--   http://www.apache.org/licenses/LICENSE-2.0-->
-<!---->
-<!-- Unless required by applicable law or agreed to in writing,-->
-<!-- software distributed under the License is distributed on an-->
-<!-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY-->
-<!-- KIND, either express or implied.  See the License for the-->
-<!-- specific language governing permissions and limitations-->
-<!-- under the License.-->
-<!-- NOTE: For help with the syntax of this file, see:-->
-<!-- http://maven.apache.org/doxia/references/apt-format.html-->
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
 
 # doxia-module-markdown
 

--- a/doxia-modules/doxia-module-xdoc/src/site/markdown/using-xdoc-xsd.md
+++ b/doxia-modules/doxia-module-xdoc/src/site/markdown/using-xdoc-xsd.md
@@ -5,22 +5,24 @@ author:
 date: 2009-01-28
 ---
 
-<!-- Licensed to the Apache Software Foundation (ASF) under one-->
-<!-- or more contributor license agreements.  See the NOTICE file-->
-<!-- distributed with this work for additional information-->
-<!-- regarding copyright ownership.  The ASF licenses this file-->
-<!-- to you under the Apache License, Version 2.0 (the-->
-<!-- "License"); you may not use this file except in compliance-->
-<!-- with the License.  You may obtain a copy of the License at-->
-<!---->
-<!--   http://www.apache.org/licenses/LICENSE-2.0-->
-<!---->
-<!-- Unless required by applicable law or agreed to in writing,-->
-<!-- software distributed under the License is distributed on an-->
-<!-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY-->
-<!-- KIND, either express or implied.  See the License for the-->
-<!-- specific language governing permissions and limitations-->
-<!-- under the License.-->
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
 
 # Using Schema XDOC 2\.0
 

--- a/doxia-sink-api/src/site/markdown/index.md
+++ b/doxia-sink-api/src/site/markdown/index.md
@@ -5,22 +5,24 @@ author:
 date: 2010-05-08
 ---
 
-<!-- Licensed to the Apache Software Foundation (ASF) under one-->
-<!-- or more contributor license agreements.  See the NOTICE file-->
-<!-- distributed with this work for additional information-->
-<!-- regarding copyright ownership.  The ASF licenses this file-->
-<!-- to you under the Apache License, Version 2.0 (the-->
-<!-- "License"); you may not use this file except in compliance-->
-<!-- with the License.  You may obtain a copy of the License at-->
-<!---->
-<!--   http://www.apache.org/licenses/LICENSE-2.0-->
-<!---->
-<!-- Unless required by applicable law or agreed to in writing,-->
-<!-- software distributed under the License is distributed on an-->
-<!-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY-->
-<!-- KIND, either express or implied.  See the License for the-->
-<!-- specific language governing permissions and limitations-->
-<!-- under the License.-->
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
 
 # Doxia Sink API
 

--- a/src/site/markdown/index.md
+++ b/src/site/markdown/index.md
@@ -5,22 +5,22 @@ author:
 ---
 
 <!--
-/*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
 -->
 
 # Doxia


### PR DESCRIPTION
An earlier APT to Markdown conversion left the header as one HTML comment
per line, and in one page as a Java block comment wrapped in an HTML
comment. Both are hard to read and neither matches the header every other
file in the project carries.

They are now the plain block form. RAT still recognises it.

<sub>Drafted with Claude — please verify</sub>