### PR TITLE
Restore the common wording on the download page

### DIFF
--- a/src/site/xdoc/download.xml.vm
+++ b/src/site/xdoc/download.xml.vm
@@ -27,44 +27,48 @@ under the License.
   <body>
     <section name="Download ${project.name} ${project.version} Source">
 
-    <p><strong>${project.name} ${project.version}</strong> is distributed in source format.</p>
+      <p><strong>${project.name} ${project.version}</strong> is distributed in source format.</p>
 
-    <p>Use a source archive if you intend to build <strong>${project.name}</strong> yourself.</p>
+      <p>Use a source archive if you intend to build <strong>${project.name}</strong> yourself.</p>
 
-    <p>Otherwise, simply use the ready-made binary artifacts from <strong>central repository</strong>.</p>
+      <p>Otherwise, simply use the ready-made binary artifacts from <strong>central repository</strong>.</p>
 
-    <p><strong>${project.name}</strong> is distributed under the <a href="https://www.apache.org/licenses/">Apache License, version 2.0</a>.</p>
+      <p><strong>${project.name}</strong> is distributed under the <a href="https://www.apache.org/licenses/">Apache License, version 2.0</a>.</p>
 
       <subsection name="Files">
-        
-      <p>This is the current stable version of <strong>${project.name}</strong>.</p>
-        
-      <table>
-        <thead>
-          <tr>
-            <th></th>
-            <th>Link</th>
-            <th>Checksum</th>
-            <th>Signature</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td>${project.name} ${project.version} (Source zip)</td>
-            <td><a href="https://dlcdn.apache.org/maven/doxia/${project.artifactId}-${project.version}-source-release.zip">maven/doxia/${project.artifactId}-${project.version}-source-release.zip</a></td>
-            <td><a href="https://downloads.apache.org/maven/doxia/${project.artifactId}-${project.version}-source-release.zip.sha512">maven/doxia/${project.artifactId}-${project.version}-source-release.zip.sha512</a></td>
-            <td><a href="https://downloads.apache.org/maven/doxia/${project.artifactId}-${project.version}-source-release.zip.asc">maven/doxia/${project.artifactId}-${project.version}-source-release.zip.asc</a></td>
-          </tr>
-        </tbody>
-      </table>
+
+        <p>This is the current stable version of <strong>${project.name}</strong>.</p>
+
+        <table>
+          <thead>
+            <tr>
+              <th></th>
+              <th>Link</th>
+              <th>Checksum</th>
+              <th>Signature</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>${project.name} ${project.version} (Source zip)</td>
+              <td><a href="https://dlcdn.apache.org/maven/doxia/${project.artifactId}-${project.version}-source-release.zip">${project.artifactId}-${project.version}-source-release.zip</a></td>
+              <td><a href="https://downloads.apache.org/maven/doxia/${project.artifactId}-${project.version}-source-release.zip.sha512">${project.artifactId}-${project.version}-source-release.zip.sha512</a></td>
+              <td><a href="https://downloads.apache.org/maven/doxia/${project.artifactId}-${project.version}-source-release.zip.asc">${project.artifactId}-${project.version}-source-release.zip.asc</a></td>
+            </tr>
+          </tbody>
+        </table>
+
+        <p>It is essential that you <a href="https://www.apache.org/info/verification.html">verify the integrity</a> of the downloaded file
+          using the checksum (.sha512 file)
+          or using the signature (.asc file) against the public <a href="https://downloads.apache.org/maven/KEYS">KEYS</a> used by the Apache Maven developers.
+        </p>
+
       </subsection>
 
       <subsection name="Previous Versions">
-        
-      <p>Older non-recommended releases can be found on our <a href="http://archive.apache.org/dist/maven/doxia/">archive site</a>.</p>
-
+        <p>It is strongly recommended to use the latest release version of <strong>${project.name}</strong> to take advantage of the newest features and bug fixes.</p>
+        <p>Older non-recommended releases can be found on our <a href="https://archive.apache.org/dist/maven/doxia/">archive site</a>.</p>
       </subsection>
     </section>
   </body>
 </document>
-


### PR DESCRIPTION
The wording on this page had drifted from the text the rest of the Maven estate uses. This restores the shared form so the page is identical to its counterparts apart from the distribution area and the artifact name.

This is worth doing rather than cosmetic: in `apache/maven-shared-utils` the same kind of rewording had **silently dropped three hyperlinks** — the verification instructions, the KEYS file and the archive site — leaving them as plain prose. A link-set audit was run across every repository in this sweep to catch that class of loss.

No URL and no in-page anchor changes. `download.cgi` is left in place. The ASF licence header is left byte-for-byte as it was.

### Verification

Generated from a single canonical template that reproduces the existing form exactly; XML well-formedness checked and the link set compared before and after. Representative repositories were rendered before and after with a real site build. **This specific repository was not individually rendered** unless noted. Draft until CI is green.