### PR TITLE
Drop branch protection for the retired doxia-1.x line

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -10,7 +10,6 @@ github:
     - doxia
   protected_branches:
     master: { }
-    doxia-1.x: { }
   pull_requests:
     del_branch_on_merge: true
   enabled_merge_buttons:


### PR DESCRIPTION
Prerequisite for retiring `doxia-1.x`; see apache/maven-doxia#1079 for the containment evidence
and what the retirement costs. Nothing else in the file changes.

*This change was created with AI assistance.*
