### PR TITLE
Drop the surefire exclusion for a test that no longer exists

### DIFF
--- a/doxia-modules/doxia-module-xdoc/pom.xml
+++ b/doxia-modules/doxia-module-xdoc/pom.xml
@@ -68,21 +68,6 @@ under the License.
     </dependency>
   </dependencies>
 
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <configuration>
-          <excludes>
-            <!-- See DOXIA-408 -->
-            <exclude>org/apache/maven/doxia/module/xdoc/XmlWriterXdocSinkTest.java</exclude>
-          </excludes>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
-
   <profiles>
     <profile>
       <id>reporting</id>


### PR DESCRIPTION
The xdoc module excludes `XmlWriterXdocSinkTest` from surefire. That test was disabled in 2010 under DOXIA-408 — it failed on Windows and covered an already-deprecated feature — and was then deleted outright in `8e689f84` ("[DOXIA-632] Remove remaining deprecated code"), along with `XmlWriterXdocSink` itself. The exclusion outlived both and now names a file that is not there.

Removing it takes the whole `<build>` section with it, since the exclusion was the only thing in it.

Verified: the module runs the same 134 tests before and after, so the exclusion was matching nothing.

*This change was created with AI assistance.*