### PR TITLE
Make the deprecation of AbstractParser#getBasedir visible to callers

### DIFF
--- a/doxia-core/src/main/java/org/apache/maven/doxia/parser/AbstractParser.java
+++ b/doxia-core/src/main/java/org/apache/maven/doxia/parser/AbstractParser.java
@@ -159,6 +159,7 @@ public abstract class AbstractParser implements Parser, MacroExecutor {
      * @return the base directory
      * @deprecated this does not work in multi-module builds, see DOXIA-373
      */
+    @Deprecated
     protected File getBasedir() {
         // TODO: This is baaad, it should come in with the request.
         // (this is only used for macro requests, see AptParser)


### PR DESCRIPTION
The javadoc on `AbstractParser#getBasedir()` has carried an `@deprecated` tag since DOXIA-373 was raised, but without the annotation no caller ever saw a warning. Anyone subclassing `AbstractParser` could reach for it and never learn it does not work in multi-module builds.

Adding the annotation is binary-compatible — japicmp passes against the 2.0.0 baseline — so this fits the 2.x line, unlike removing the method.

**One judgement call worth your view.** This surfaces four warnings inside Doxia itself, all at the `MacroRequest` construction in the APT, FML, xdoc and XHTML5 parsers. I left them in place rather than adding `@SuppressWarnings`: there is no replacement for the basedir those parsers need, and silencing the warnings would hide DOXIA-373 in the one codebase that can actually fix it. `AptParser` already carries a comment saying as much. If you would rather the build stayed quiet, suppressing at those four sites is a one-line change each — say the word.

Verified: `mvn clean verify` → 667 tests pass, japicmp clean, and the only new warnings are the four expected call sites.

*This change was created with AI assistance.*