### PR TITLE
Render unknown Sink events as raw HTML in MarkdownSink

### DIFF
--- a/doxia-modules/doxia-module-markdown/src/main/java/org/apache/maven/doxia/module/markdown/MarkdownSink.java
+++ b/doxia-modules/doxia-module-markdown/src/main/java/org/apache/maven/doxia/module/markdown/MarkdownSink.java
@@ -38,6 +38,7 @@ import org.apache.maven.doxia.sink.impl.Xhtml5BaseSink;
 import org.apache.maven.doxia.util.DoxiaStringUtils;
 import org.apache.maven.doxia.util.DoxiaUtils;
 import org.apache.maven.doxia.util.HtmlTools;
+import org.jsoup.parser.Tag;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -1360,15 +1361,49 @@ public class MarkdownSink extends Xhtml5BaseSink implements MarkdownMarkup {
         write(text);
     }
 
+    /** Table row-grouping tags without their own content: {@link #unknown(String, Object[], SinkEventAttributes)}
+     * ignores these rather than rendering them as raw HTML. */
+    private static final Collection<String> IGNORED_TABLE_GROUPING_TAGS =
+            Collections.unmodifiableList(Arrays.asList("thead", "tbody", "tfoot"));
+
     /**
      * {@inheritDoc}
      *
-     * Unknown events just log a warning message but are ignored otherwise.
+     * Delegates tag reconstruction and attribute escaping to
+     * {@link Xhtml5BaseSink#unknown(String, Object[], SinkEventAttributes)}, so any tag recognized by
+     * {@link HtmlTools#getHtmlTag(String)} (e.g. {@code <object>}, {@code <map>}/{@code <area>}) is emitted as raw
+     * HTML instead of being silently dropped.
+     * <p>
+     * Unlike that XHTML sink, a {@link #TAG_TYPE_SIMPLE} event for a non-void element is never self-closed
+     * ({@code <name/>}): HTML5 has no self-closing syntax outside the fixed list of void elements, so a
+     * self-closed non-void tag such as {@code <object/>} would otherwise be re-parsed as an open tag that
+     * swallows all following content as its own (hidden) fallback children. Such events are instead written as
+     * an explicitly closed pair ({@code <name></name>}).
+     * <p>
+     * {@code <thead>}/{@code <tbody>}/{@code <tfoot>} are excluded: they carry no content of their own (Doxia's
+     * table sink API already fully captures the table structure via {@code table()}/{@code tableRows()}/
+     * {@code tableRow()}/{@code tableCell()}), and {@link MarkdownParser} fires these as unknown events for
+     * every table it parses (they have no dedicated sink method). Rendering them as raw HTML would inject a
+     * tag directly before the first cell of a row, which breaks GFM pipe-table syntax since a table row must
+     * start at the beginning of its line.
+     *
      * @see org.apache.maven.doxia.sink.Sink#unknown(String,Object[],SinkEventAttributes)
      */
     @Override
     public void unknown(String name, Object[] requiredParams, SinkEventAttributes attributes) {
-        LOGGER.warn("{}Unknown Sink event '" + name + "', ignoring!", getLocationLogPrefix());
+        if (IGNORED_TABLE_GROUPING_TAGS.contains(name)) {
+            return;
+        }
+        if (requiredParams != null
+                && requiredParams[0] instanceof Integer
+                && (Integer) requiredParams[0] == TAG_TYPE_SIMPLE
+                && HtmlTools.getHtmlTag(name) != null
+                && !Tag.valueOf(name).isSelfClosing()) {
+            super.unknown(name, new Object[] {TAG_TYPE_START}, attributes);
+            super.unknown(name, new Object[] {TAG_TYPE_END}, null);
+            return;
+        }
+        super.unknown(name, requiredParams, attributes);
     }
 
     @Override

--- a/doxia-modules/doxia-module-markdown/src/test/java/org/apache/maven/doxia/module/markdown/MarkdownSinkTest.java
+++ b/doxia-modules/doxia-module-markdown/src/test/java/org/apache/maven/doxia/module/markdown/MarkdownSinkTest.java
@@ -34,6 +34,7 @@ import org.apache.maven.doxia.sink.impl.AbstractSinkTest;
 import org.apache.maven.doxia.sink.impl.SinkEventAttributeSet;
 import org.apache.maven.doxia.sink.impl.SinkEventAttributeSet.Semantics;
 import org.apache.maven.doxia.sink.impl.SinkEventTestingSink;
+import org.apache.maven.doxia.sink.impl.Xhtml5BaseSink;
 import org.apache.maven.doxia.util.DoxiaStringUtils;
 import org.junit.jupiter.api.Test;
 
@@ -740,5 +741,49 @@ class MarkdownSinkTest extends AbstractSinkTest {
                 + "|<pre><code>code with | and ` inside</code></pre>|" + EOL
                 + "|<pre><code>code with | and ` inside</code></pre>|" + EOL + EOL;
         assertEquals(expected, getSinkContent());
+    }
+
+    /**
+     * A self-closing {@code <object/>} (as xdoc's parser emits it, i.e. a single {@code unknown} event with
+     * {@link Xhtml5BaseSink#TAG_TYPE_SIMPLE}) is not a void HTML element, so it must never be rendered
+     * self-closed: HTML5 ignores the trailing slash on a non-void tag and would otherwise treat everything that
+     * follows as {@code <object>} fallback content. See MDOXIA-159.
+     */
+    @Test
+    void unknownObjectEventIsRenderedAsExplicitlyClosedRawHtml() throws IOException {
+        SinkEventAttributeSet attributes = new SinkEventAttributeSet();
+        attributes.addAttribute("type", "image/svg+xml");
+        attributes.addAttribute("data", "x.svg");
+
+        try (Sink sink = getSink()) {
+            sink.unknown("object", new Object[] {Xhtml5BaseSink.TAG_TYPE_SIMPLE}, attributes);
+        }
+
+        assertEquals("<object type=\"image/svg+xml\" data=\"x.svg\"></object>", getSinkContent());
+    }
+
+    /**
+     * An image map ({@code <map>} wrapping a void {@code <area/>}) must survive conversion instead of being
+     * silently dropped like any other unknown event previously was. Unlike {@code <object>}, {@code <area>} is a
+     * void element, so it is still fine to render it self-closed. See MDOXIA-159.
+     */
+    @Test
+    void unknownMapAndAreaEventsAreRenderedAsRawHtml() throws IOException {
+        SinkEventAttributeSet mapAttributes = new SinkEventAttributeSet();
+        mapAttributes.addAttribute("name", "imgmap");
+        SinkEventAttributeSet areaAttributes = new SinkEventAttributeSet();
+        areaAttributes.addAttribute("shape", "rect");
+        areaAttributes.addAttribute("coords", "0,0,10,10");
+        areaAttributes.addAttribute("href", "a.html");
+
+        try (Sink sink = getSink()) {
+            sink.unknown("map", new Object[] {Xhtml5BaseSink.TAG_TYPE_START}, mapAttributes);
+            sink.unknown("area", new Object[] {Xhtml5BaseSink.TAG_TYPE_SIMPLE}, areaAttributes);
+            sink.unknown("map", new Object[] {Xhtml5BaseSink.TAG_TYPE_END}, null);
+        }
+
+        assertEquals(
+                "<map name=\"imgmap\"><area shape=\"rect\" coords=\"0,0,10,10\" href=\"a.html\" /></map>",
+                getSinkContent());
     }
 }


### PR DESCRIPTION
`MarkdownSink.unknown()` logged a warning and silently dropped any Sink event it had no dedicated handling for, taking the content it carried with it (e.g. `<object>` embeds, image maps). It now delegates tag reconstruction to `Xhtml5BaseSink.unknown()` and emits the raw HTML tag instead, restoring that content in the converted output. `<thead>`/`<tbody>`/`<tfoot>` stay excluded, since they carry no content of their own and Doxia's table sink API already captures the structure they wrap.

Aligned with #1087 (`xdoc-selfclosing-raw-html`): a self-closing, non-void tag (e.g. `<object/>`) is never rendered self-closed, since HTML5 ignores the trailing slash on non-void elements and would otherwise swallow all following content as fallback children. It is written as an explicitly closed pair instead.

Root-cause fix for apache/maven-doxia-converter#159.

Verified: end-to-end conversion of the issue's xdoc fixture (`<object type="image/svg+xml" data="x.svg"/>`) through a locally built `doxia-converter` now yields `<object type="image/svg+xml" data="x.svg"></object>` in the Markdown output instead of silently vanishing.

*This change was created with AI assistance.*