### PR TITLE
Make SinkEventAttributeSet.hashCode ignore resolveParent (#1075)

### DIFF
--- a/doxia-sink-api/src/main/java/org/apache/maven/doxia/sink/SinkEventAttributeSet.java
+++ b/doxia-sink-api/src/main/java/org/apache/maven/doxia/sink/SinkEventAttributeSet.java
@@ -356,9 +356,7 @@ public class SinkEventAttributeSet implements SinkEventAttributes, Cloneable {
 
     @Override
     public int hashCode() {
-        final int parentHash = (resolveParent == null ? 0 : resolveParent.hashCode());
-
-        return attribs.hashCode() + parentHash;
+        return attribs.hashCode();
     }
 
     @Override

--- a/doxia-sink-api/src/test/java/org/apache/maven/doxia/sink/SinkEventAttributeSetTest.java
+++ b/doxia-sink-api/src/test/java/org/apache/maven/doxia/sink/SinkEventAttributeSetTest.java
@@ -259,7 +259,20 @@ class SinkEventAttributeSetTest {
         oldValue = newValue;
         sinkEventAttributeSet.setResolveParent(SinkEventAttributeSet.CENTER);
         newValue = sinkEventAttributeSet.hashCode();
-        assertNotEquals(oldValue, newValue);
+        assertEquals(oldValue, newValue);
+    }
+
+    /**
+     * Own attributes decide equality; resolveParent must not break the hashCode contract.
+     */
+    @Test
+    void hashCodeAgreesWithEqualsWhenResolveParentDiffers() {
+        SinkEventAttributeSet a = new SinkEventAttributeSet(SinkEventAttributeSet.BOLD);
+        SinkEventAttributeSet b = new SinkEventAttributeSet(SinkEventAttributeSet.BOLD);
+        a.setResolveParent(SinkEventAttributeSet.CENTER);
+        b.setResolveParent(SinkEventAttributeSet.LEFT);
+        assertEquals(a, b);
+        assertEquals(a.hashCode(), b.hashCode());
     }
 
     /**


### PR DESCRIPTION
`SinkEventAttributeSet.equals()` already delegates to `isEqual()`, which compares only own attributes. `hashCode()` was adding the resolve parent, so two equal sets could have different hash codes.

I dropped the parent from `hashCode()` so it matches existing equality. `getAttribute()` still walks the parent. This is the least disruptive option from #1075. I did not change equals semantics.

`checkHashCode` now expects `setResolveParent` not to change the hash. I also added a contract test for two sets with the same own attributes and different parents.

This is independent of #1073 (the class move). Happy to rebase if that lands first.

Fixes #1075

Following this checklist to help us incorporate your
contribution quickly and easily:

- [x] Your pull request should address just one issue, without pulling in other changes.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body.
  Note that commits might be squashed by a maintainer on merge.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied.
  This may not always be possible but is a best-practice.
- [x] Run `mvn verify` to make sure basic checks pass.
  A more thorough check will be performed on your pull request automatically.
- [ ] You have run the integration tests successfully (`mvn -Prun-its verify`).

I ran `mvn -pl doxia-core -am test -Dtest=SinkEventAttributeSetTest -Dsurefire.failIfNoSpecifiedTests=false` locally (18 tests, green, including checkstyle/spotless/rat on those modules). I did not run `-Prun-its`.

- [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).