### PR TITLE
Deprecate the parser hooks that will be retyped to SinkEventAttributes

### DIFF
--- a/doxia-core/src/main/java/org/apache/maven/doxia/parser/AbstractXmlParser.java
+++ b/doxia-core/src/main/java/org/apache/maven/doxia/parser/AbstractXmlParser.java
@@ -167,7 +167,12 @@ public abstract class AbstractXmlParser extends AbstractParser implements XmlMar
      * @param parser A parser, not null.
      * @return a SinkEventAttributeSet or null if the current parser event is not a start tag.
      * @since 1.1
+     * @deprecated The return type will become {@link org.apache.maven.doxia.sink.SinkEventAttributes} in the next
+     *      major version. Callers are unaffected if they declare the result as that interface; every use in Doxia
+     *      itself already needs nothing more than the interface. An override of this method will stop being called
+     *      once the return type changes, with no error at build or run time. See <a href="https://github.com/apache/maven-doxia/issues/1074">issue 1074</a>.
      */
+    @Deprecated
     protected SinkEventAttributeSet getAttributesFromParser(XmlPullParser parser) {
         int count = parser.getAttributeCount();
 
@@ -382,6 +387,22 @@ public abstract class AbstractXmlParser extends AbstractParser implements XmlMar
         handleUnknown(parser.getName(), attribs, sink, type);
     }
 
+    /**
+     * Emits an element that has no dedicated Sink event as
+     * {@link Sink#unknown(String, Object[], org.apache.maven.doxia.sink.SinkEventAttributes)}.
+     *
+     * @param elementName the name of the element.
+     * @param attribs the attributes of the element, may be null.
+     * @param sink the sink to receive the event.
+     * @param type the tag event type, passed as the first required parameter of the Sink event. This should be one
+     *      of HtmlMarkup.TAG_TYPE_SIMPLE, HtmlMarkup.TAG_TYPE_START, HtmlMarkup.TAG_TYPE_END or
+     *      HtmlMarkup.ENTITY_TYPE.
+     * @deprecated The {@code attribs} parameter will become
+     *      {@link org.apache.maven.doxia.sink.SinkEventAttributes} in the next major version.
+     *      An override of this signature will stop being called once the parameter type changes, with no error
+     *      at build or run time, so move the override to the new signature when it lands. See <a href="https://github.com/apache/maven-doxia/issues/1074">issue 1074</a>.
+     */
+    @Deprecated
     protected void handleUnknown(String elementName, SinkEventAttributeSet attribs, Sink sink, int type) {
         Object[] required = new Object[] {type};
         sink.unknown(elementName, required, attribs);

--- a/doxia-core/src/main/java/org/apache/maven/doxia/parser/AbstractXmlParser.java
+++ b/doxia-core/src/main/java/org/apache/maven/doxia/parser/AbstractXmlParser.java
@@ -167,8 +167,8 @@ public abstract class AbstractXmlParser extends AbstractParser implements XmlMar
      * @param parser A parser, not null.
      * @return a SinkEventAttributeSet or null if the current parser event is not a start tag.
      * @since 1.1
-     * @deprecated The return type will become {@link org.apache.maven.doxia.sink.SinkEventAttributes} in the next
-     *      major version. Callers are unaffected if they declare the result as that interface; every use in Doxia
+     * @deprecated The return type will become {@link org.apache.maven.doxia.sink.SinkEventAttributes} in 2.3.0.
+     *      Callers are unaffected if they declare the result as that interface; every use in Doxia
      *      itself already needs nothing more than the interface. An override of this method will stop being called
      *      once the return type changes, with no error at build or run time. See <a href="https://github.com/apache/maven-doxia/issues/1074">issue 1074</a>.
      */
@@ -398,7 +398,7 @@ public abstract class AbstractXmlParser extends AbstractParser implements XmlMar
      *      of HtmlMarkup.TAG_TYPE_SIMPLE, HtmlMarkup.TAG_TYPE_START, HtmlMarkup.TAG_TYPE_END or
      *      HtmlMarkup.ENTITY_TYPE.
      * @deprecated The {@code attribs} parameter will become
-     *      {@link org.apache.maven.doxia.sink.SinkEventAttributes} in the next major version.
+     *      {@link org.apache.maven.doxia.sink.SinkEventAttributes} in 2.3.0.
      *      An override of this signature will stop being called once the parameter type changes, with no error
      *      at build or run time, so move the override to the new signature when it lands. See <a href="https://github.com/apache/maven-doxia/issues/1074">issue 1074</a>.
      */

--- a/doxia-core/src/main/java/org/apache/maven/doxia/parser/Xhtml1BaseParser.java
+++ b/doxia-core/src/main/java/org/apache/maven/doxia/parser/Xhtml1BaseParser.java
@@ -148,6 +148,7 @@ public class Xhtml1BaseParser extends Xhtml5BaseParser {
      * Translates obsolete XHTML 1.0 attributes/elements to valid XHTML5 ones before calling the underlying {@link Xhtml5BaseParser}.
      */
     @Override
+    @SuppressWarnings("deprecation")
     protected boolean baseStartTag(XmlPullParser parser, Sink sink) {
         SinkEventAttributeSet attribs = getAttributesFromParser(parser);
         String elementName = parser.getName();
@@ -173,6 +174,7 @@ public class Xhtml1BaseParser extends Xhtml5BaseParser {
     }
 
     @Override
+    @SuppressWarnings("deprecation")
     protected boolean baseEndTag(XmlPullParser parser, Sink sink) {
         SinkEventAttributeSet attribs = getAttributesFromParser(parser);
         String elementName = parser.getName();

--- a/doxia-core/src/main/java/org/apache/maven/doxia/parser/Xhtml5BaseParser.java
+++ b/doxia-core/src/main/java/org/apache/maven/doxia/parser/Xhtml5BaseParser.java
@@ -206,7 +206,7 @@ public class Xhtml5BaseParser extends AbstractXmlParser implements HtmlMarkup {
      * @param attribs the attributes of the element, may be null.
      * @param sink the sink to receive the events.
      * @return True if the event has been handled by this method, i.e. the tag was recognized, false otherwise.
-     * @deprecated The {@code attribs} parameter will become {@link SinkEventAttributes} in the next major version.
+     * @deprecated The {@code attribs} parameter will become {@link SinkEventAttributes} in 2.3.0.
      *      An override of this signature will stop being called once the parameter type changes, with no error
      *      at build or run time, so move the override to the new signature when it lands. See <a href="https://github.com/apache/maven-doxia/issues/1074">issue 1074</a>.
      */
@@ -514,7 +514,7 @@ public class Xhtml5BaseParser extends AbstractXmlParser implements HtmlMarkup {
      * @param attribs the attributes of the element, may be null.
      * @param sink the sink to receive the events.
      * @return True if the event has been handled by this method, false otherwise.
-     * @deprecated The {@code attribs} parameter will become {@link SinkEventAttributes} in the next major version.
+     * @deprecated The {@code attribs} parameter will become {@link SinkEventAttributes} in 2.3.0.
      *      An override of this signature will stop being called once the parameter type changes, with no error
      *      at build or run time, so move the override to the new signature when it lands. See <a href="https://github.com/apache/maven-doxia/issues/1074">issue 1074</a>.
      */

--- a/doxia-core/src/main/java/org/apache/maven/doxia/parser/Xhtml5BaseParser.java
+++ b/doxia-core/src/main/java/org/apache/maven/doxia/parser/Xhtml5BaseParser.java
@@ -192,11 +192,25 @@ public class Xhtml5BaseParser extends AbstractXmlParser implements HtmlMarkup {
      * @param sink the sink to receive the events.
      * @return True if the event has been handled by this method, i.e. the tag was recognized, false otherwise.
      */
+    @SuppressWarnings("deprecation")
     protected boolean baseStartTag(XmlPullParser parser, Sink sink) {
         SinkEventAttributeSet attribs = getAttributesFromParser(parser);
         return baseStartTag(parser.getName(), attribs, sink);
     }
 
+    /**
+     * Handles a start tag by element name, so that a subclass can map an element name before the common handling
+     * runs. This is what {@link Xhtml1BaseParser} uses to translate obsolete XHTML 1.0 element names.
+     *
+     * @param elementName the name of the element.
+     * @param attribs the attributes of the element, may be null.
+     * @param sink the sink to receive the events.
+     * @return True if the event has been handled by this method, i.e. the tag was recognized, false otherwise.
+     * @deprecated The {@code attribs} parameter will become {@link SinkEventAttributes} in the next major version.
+     *      An override of this signature will stop being called once the parameter type changes, with no error
+     *      at build or run time, so move the override to the new signature when it lands. See <a href="https://github.com/apache/maven-doxia/issues/1074">issue 1074</a>.
+     */
+    @Deprecated
     protected boolean baseStartTag(String elementName, SinkEventAttributeSet attribs, Sink sink) {
         boolean visited = true;
         isBeginningOfLineInsideBlock = true;
@@ -486,11 +500,25 @@ public class Xhtml5BaseParser extends AbstractXmlParser implements HtmlMarkup {
      * @param sink the sink to receive the events.
      * @return True if the event has been handled by this method, false otherwise.
      */
+    @SuppressWarnings("deprecation")
     protected boolean baseEndTag(XmlPullParser parser, Sink sink) {
         SinkEventAttributeSet attribs = getAttributesFromParser(parser);
         return baseEndTag(parser.getName(), attribs, sink);
     }
 
+    /**
+     * Handles an end tag by element name, so that a subclass can map an element name before the common handling
+     * runs. This is what {@link Xhtml1BaseParser} uses to translate obsolete XHTML 1.0 element names.
+     *
+     * @param elementName the name of the element.
+     * @param attribs the attributes of the element, may be null.
+     * @param sink the sink to receive the events.
+     * @return True if the event has been handled by this method, false otherwise.
+     * @deprecated The {@code attribs} parameter will become {@link SinkEventAttributes} in the next major version.
+     *      An override of this signature will stop being called once the parameter type changes, with no error
+     *      at build or run time, so move the override to the new signature when it lands. See <a href="https://github.com/apache/maven-doxia/issues/1074">issue 1074</a>.
+     */
+    @Deprecated
     protected boolean baseEndTag(String elementName, SinkEventAttributeSet attribs, Sink sink) {
         boolean visited = true;
         isBeginningOfLineInsideBlock = true;

--- a/doxia-modules/doxia-module-xdoc/src/main/java/org/apache/maven/doxia/module/xdoc/XdocParser.java
+++ b/doxia-modules/doxia-module-xdoc/src/main/java/org/apache/maven/doxia/module/xdoc/XdocParser.java
@@ -106,6 +106,7 @@ public class XdocParser extends Xhtml1BaseParser implements XdocMarkup {
         }
     }
 
+    @SuppressWarnings("deprecation")
     protected void handleStartTag(XmlPullParser parser, Sink sink)
             throws XmlPullParserException, MacroExecutionException {
         isEmptyElement = parser.isEmptyElementTag();

--- a/doxia-modules/doxia-module-xhtml5/src/main/java/org/apache/maven/doxia/module/xhtml5/Xhtml5Parser.java
+++ b/doxia-modules/doxia-module-xhtml5/src/main/java/org/apache/maven/doxia/module/xhtml5/Xhtml5Parser.java
@@ -62,6 +62,7 @@ public class Xhtml5Parser extends Xhtml5BaseParser implements Xhtml5Markup {
      */
     private String sourceContent;
 
+    @SuppressWarnings("deprecation")
     protected void handleStartTag(XmlPullParser parser, Sink sink)
             throws XmlPullParserException, MacroExecutionException {
         isEmptyElement = parser.isEmptyElementTag();


### PR DESCRIPTION
Marks the four hooks from #1074 that will be retyped to `SinkEventAttributes` in the next major.

The point is that the retype is a silent break: an override compiled against the old signature
stops overriding and is simply never called again, with nothing failing at build or run time.
A deprecation warning now is the only notice a downstream parser author gets. Of the five hooks
#1074 lists, only `consecutiveSections` was already marked.

Two things worth a reviewer's attention:

`getAttributesFromParser` is the weakest of the four. Its problem is only the return type, and all
seven call sites use nothing beyond the interface (`getAttribute`, `addAttribute`,
`removeAttribute`), so the eventual retype needs no caller changes at all. Nothing in the repo
overrides it either. So this one warns correct code to protect a hypothetical overrider — happy to
drop it from the set if you would rather.

Deprecating `baseStartTag(String, ...)` and `baseEndTag(String, ...)` also silences the
pre-existing `impl.SinkEventAttributeSet` warnings inside their bodies, because the JLS does not
warn for uses within a deprecated declaration. doxia-core goes from 84 deprecation warnings to 18.
Nothing was fixed; the warnings moved out of view. Flagging it so it is not mistaken for progress.

Verified: `mvn verify` green (japicmp, RAT, checkstyle, all tests); `mvn javadoc:javadoc` green with
0 errors and no warning on any added block; deprecation-warning counts compared against master
built to the identical reactor point.

Part of #1074

*This change was created with AI assistance.*
