### PR TITLE
Drop the HTML.Attribute dependency from the parsers and sinks

### DIFF
--- a/doxia-core/src/main/java/org/apache/maven/doxia/parser/Xhtml5BaseParser.java
+++ b/doxia-core/src/main/java/org/apache/maven/doxia/parser/Xhtml5BaseParser.java
@@ -18,8 +18,6 @@
  */
 package org.apache.maven.doxia.parser;
 
-import javax.swing.text.html.HTML.Attribute;
-
 import java.io.Reader;
 import java.text.CharacterIterator;
 import java.text.StringCharacterIterator;
@@ -985,13 +983,13 @@ public class Xhtml5BaseParser extends AbstractXmlParser implements HtmlMarkup {
     }
 
     private void handleAStart(Sink sink, SinkEventAttributeSet attribs) {
-        String href = (String) attribs.getAttribute(Attribute.HREF.toString());
+        String href = (String) attribs.getAttribute(SinkEventAttributes.HREF);
 
         if (href != null) {
             int hashIndex = href.indexOf('#');
             if (hashIndex != -1
                     && !DoxiaUtils.isExternalLink(href)
-                    && !"external".equals(attribs.getAttribute(Attribute.REL.toString()))) {
+                    && !"external".equals(attribs.getAttribute(SinkEventAttributes.REL))) {
                 String hash = href.substring(hashIndex + 1);
 
                 if (!DoxiaUtils.isValidId(hash)) {
@@ -1003,11 +1001,11 @@ public class Xhtml5BaseParser extends AbstractXmlParser implements HtmlMarkup {
             sink.link(href, attribs);
             isLink = true;
         } else {
-            String id = (String) attribs.getAttribute(Attribute.ID.toString());
+            String id = (String) attribs.getAttribute(SinkEventAttributes.ID);
             if (id == null) {
                 // although the "name" attribute is obsolete in HTML5, it is still allowed
                 // (https://www.w3.org/TR/html5-diff/#obsolete-attributes)
-                id = (String) attribs.getAttribute(Attribute.NAME.toString());
+                id = (String) attribs.getAttribute(SinkEventAttributes.NAME);
             }
             if (id != null) {
                 sink.anchor(validAnchor(id), attribs);
@@ -1017,7 +1015,7 @@ public class Xhtml5BaseParser extends AbstractXmlParser implements HtmlMarkup {
     }
 
     private boolean handleDivStart(SinkEventAttributeSet attribs, Sink sink) {
-        String divClass = (String) attribs.getAttribute(Attribute.CLASS.toString());
+        String divClass = (String) attribs.getAttribute(SinkEventAttributes.CLASS);
 
         this.divStack.push(divClass);
 
@@ -1051,7 +1049,7 @@ public class Xhtml5BaseParser extends AbstractXmlParser implements HtmlMarkup {
     }
 
     private void handleImgStart(Sink sink, SinkEventAttributeSet attribs) {
-        String src = (String) attribs.getAttribute(Attribute.SRC.toString());
+        String src = (String) attribs.getAttribute(SinkEventAttributes.SRC);
 
         if (src != null) {
             sink.figureGraphics(src, attribs);
@@ -1077,7 +1075,7 @@ public class Xhtml5BaseParser extends AbstractXmlParser implements HtmlMarkup {
     private void handleOLStart(Sink sink, SinkEventAttributeSet attribs) {
         int numbering = Sink.NUMBERING_DECIMAL;
         // this will have to be generalized if we handle styles
-        String style = (String) attribs.getAttribute(Attribute.STYLE.toString());
+        String style = (String) attribs.getAttribute(SinkEventAttributes.STYLE);
 
         if (style != null) {
             switch (style) {
@@ -1143,7 +1141,7 @@ public class Xhtml5BaseParser extends AbstractXmlParser implements HtmlMarkup {
 
     private void handleTableStart(Sink sink, SinkEventAttributeSet attribs) {
         sink.table(attribs);
-        String givenTableClass = (String) attribs.getAttribute(Attribute.CLASS.toString());
+        String givenTableClass = (String) attribs.getAttribute(SinkEventAttributes.CLASS);
         boolean grid = false;
         if (givenTableClass != null
                 && BODYTABLEBORDER_CLASS_PATTERN.matcher(givenTableClass).matches()) {

--- a/doxia-core/src/main/java/org/apache/maven/doxia/sink/impl/Xhtml5BaseSink.java
+++ b/doxia-core/src/main/java/org/apache/maven/doxia/sink/impl/Xhtml5BaseSink.java
@@ -1666,12 +1666,8 @@ public class Xhtml5BaseSink extends AbstractXmlSink implements HtmlMarkup {
     private SinkEventAttributes escapeAttributeValues(SinkEventAttributes attributes) {
         SinkEventAttributeSet set = new SinkEventAttributeSet(attributes.getAttributeCount());
 
-        Enumeration<?> names = attributes.getAttributeNames();
-
-        while (names.hasMoreElements()) {
-            Object name = names.nextElement();
-
-            set.addAttribute(name, escapeHTML(attributes.getAttribute(name).toString()));
+        for (Map.Entry<String, Object> attribute : attributes.entrySet()) {
+            set.addAttribute(attribute.getKey(), escapeHTML(attribute.getValue().toString()));
         }
 
         return set;

--- a/doxia-core/src/test/java/org/apache/maven/doxia/sink/impl/Xhtml5BaseSinkTest.java
+++ b/doxia-core/src/test/java/org/apache/maven/doxia/sink/impl/Xhtml5BaseSinkTest.java
@@ -19,7 +19,6 @@
 package org.apache.maven.doxia.sink.impl;
 
 import javax.swing.text.AttributeSet;
-import javax.swing.text.html.HTML.Attribute;
 
 import java.io.StringWriter;
 import java.io.Writer;
@@ -674,13 +673,13 @@ class Xhtml5BaseSinkTest {
         final SinkEventAttributes att = new SinkEventAttributeSet(SinkEventAttributes.ID, "id");
         checkVerbatimAttributes(att, "<pre id=\"id\"></pre>");
 
-        att.addAttribute(Attribute.CLASS, "class");
+        att.addAttribute(SinkEventAttributes.CLASS, "class");
         checkVerbatimAttributes(att, "<pre id=\"id\" class=\"class\"></pre>");
 
         att.addAttribute(SinkEventAttributes.DECORATION, "source");
         checkVerbatimAttributes(att, "<pre id=\"id\" class=\"class\"><code></code></pre>");
 
-        att.removeAttribute(Attribute.CLASS.toString());
+        att.removeAttribute(SinkEventAttributes.CLASS);
         checkVerbatimAttributes(att, "<pre id=\"id\"><code></code></pre>");
     }
 

--- a/doxia-modules/doxia-module-fml/src/main/java/org/apache/maven/doxia/module/fml/FmlParser.java
+++ b/doxia-modules/doxia-module-fml/src/main/java/org/apache/maven/doxia/module/fml/FmlParser.java
@@ -20,7 +20,6 @@ package org.apache.maven.doxia.module.fml;
 
 import javax.inject.Named;
 import javax.inject.Singleton;
-import javax.swing.text.html.HTML.Attribute;
 
 import java.io.IOException;
 import java.io.Reader;
@@ -42,6 +41,7 @@ import org.apache.maven.doxia.parser.AbstractXmlParser;
 import org.apache.maven.doxia.parser.ParseException;
 import org.apache.maven.doxia.sink.Sink;
 import org.apache.maven.doxia.sink.SinkEventAttributeSet;
+import org.apache.maven.doxia.sink.SinkEventAttributes;
 import org.apache.maven.doxia.sink.impl.Xhtml5BaseSink;
 import org.apache.maven.doxia.util.DoxiaStringUtils;
 import org.apache.maven.doxia.util.DoxiaUtils;
@@ -135,7 +135,7 @@ public class FmlParser extends AbstractXmlParser implements FmlMarkup {
         } else if (parser.getName().equals(PART_TAG.toString())) {
             currentPart = new Part();
 
-            currentPart.setId(parser.getAttributeValue(null, Attribute.ID.toString()));
+            currentPart.setId(parser.getAttributeValue(null, SinkEventAttributes.ID));
 
             if (currentPart.getId() == null) {
                 throw new XmlPullParserException("id attribute required for <part> at: (" + parser.getLineNumber() + ":"
@@ -153,7 +153,7 @@ public class FmlParser extends AbstractXmlParser implements FmlMarkup {
         } else if (parser.getName().equals(FAQ_TAG.toString())) {
             currentFaq = new Faq();
 
-            currentFaq.setId(parser.getAttributeValue(null, Attribute.ID.toString()));
+            currentFaq.setId(parser.getAttributeValue(null, SinkEventAttributes.ID));
 
             if (currentFaq.getId() == null) {
                 throw new XmlPullParserException("id attribute required for <faq> at: (" + parser.getLineNumber() + ":"
@@ -357,14 +357,14 @@ public class FmlParser extends AbstractXmlParser implements FmlMarkup {
      */
     private void handleMacroStart(XmlPullParser parser) throws MacroExecutionException {
         if (!isSecondParsing()) {
-            macroName = parser.getAttributeValue(null, Attribute.NAME.toString());
+            macroName = parser.getAttributeValue(null, SinkEventAttributes.NAME);
 
             if (macroParameters == null) {
                 macroParameters = new HashMap<>();
             }
 
             if (macroName == null || macroName.isEmpty()) {
-                throw new MacroExecutionException("The '" + Attribute.NAME.toString() + "' attribute for the '"
+                throw new MacroExecutionException("The '" + SinkEventAttributes.NAME + "' attribute for the '"
                         + MACRO_TAG.toString() + "' tag is required.");
             }
         }
@@ -408,12 +408,12 @@ public class FmlParser extends AbstractXmlParser implements FmlMarkup {
     private void handleParamStart(XmlPullParser parser, Sink sink) throws MacroExecutionException {
         if (!isSecondParsing()) {
             if (macroName != null && !macroName.isEmpty()) {
-                String paramName = parser.getAttributeValue(null, Attribute.NAME.toString());
-                String paramValue = parser.getAttributeValue(null, Attribute.VALUE.toString());
+                String paramName = parser.getAttributeValue(null, SinkEventAttributes.NAME);
+                String paramValue = parser.getAttributeValue(null, SinkEventAttributes.VALUE);
 
                 if ((paramName == null || paramName.isEmpty()) || (paramValue == null || paramValue.isEmpty())) {
-                    throw new MacroExecutionException("'" + Attribute.NAME.toString()
-                            + "' and '" + Attribute.VALUE.toString() + "' attributes for the '" + PARAM.toString()
+                    throw new MacroExecutionException("'" + SinkEventAttributes.NAME
+                            + "' and '" + SinkEventAttributes.VALUE + "' attributes for the '" + PARAM.toString()
                             + "' tag are required inside the '" + MACRO_TAG.toString() + "' tag.");
                 }
 

--- a/doxia-modules/doxia-module-xdoc/src/main/java/org/apache/maven/doxia/module/xdoc/XdocParser.java
+++ b/doxia-modules/doxia-module-xdoc/src/main/java/org/apache/maven/doxia/module/xdoc/XdocParser.java
@@ -20,7 +20,6 @@ package org.apache.maven.doxia.module.xdoc;
 
 import javax.inject.Named;
 import javax.inject.Singleton;
-import javax.swing.text.html.HTML.Attribute;
 
 import java.io.IOException;
 import java.io.Reader;
@@ -38,6 +37,7 @@ import org.apache.maven.doxia.parser.ParseException;
 import org.apache.maven.doxia.parser.Xhtml1BaseParser;
 import org.apache.maven.doxia.sink.Sink;
 import org.apache.maven.doxia.sink.SinkEventAttributeSet;
+import org.apache.maven.doxia.sink.SinkEventAttributes;
 import org.apache.maven.doxia.util.HtmlTools;
 import org.codehaus.plexus.util.xml.pull.XmlPullParser;
 import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
@@ -289,22 +289,22 @@ public class XdocParser extends Xhtml1BaseParser implements XdocMarkup {
 
     private void handleMacroStart(XmlPullParser parser) throws MacroExecutionException {
         if (!isSecondParsing()) {
-            macroName = parser.getAttributeValue(null, Attribute.NAME.toString());
+            macroName = parser.getAttributeValue(null, SinkEventAttributes.NAME);
 
             if (macroParameters == null) {
                 macroParameters = new HashMap<>();
             }
 
             if (macroName == null || macroName.isEmpty()) {
-                throw new MacroExecutionException("The '" + Attribute.NAME.toString() + "' attribute for the '"
+                throw new MacroExecutionException("The '" + SinkEventAttributes.NAME + "' attribute for the '"
                         + MACRO_TAG.toString() + "' tag is required.");
             }
         }
     }
 
     private void handleMetaStart(XmlPullParser parser, Sink sink, SinkEventAttributeSet attribs) {
-        String name = parser.getAttributeValue(null, Attribute.NAME.toString());
-        String content = parser.getAttributeValue(null, Attribute.CONTENT.toString());
+        String name = parser.getAttributeValue(null, SinkEventAttributes.NAME);
+        String content = parser.getAttributeValue(null, SinkEventAttributes.CONTENT);
 
         if ("author".equals(name)) {
             sink.author(null);
@@ -322,12 +322,12 @@ public class XdocParser extends Xhtml1BaseParser implements XdocMarkup {
     private void handleParamStart(XmlPullParser parser, Sink sink) throws MacroExecutionException {
         if (!isSecondParsing()) {
             if (macroName != null && !macroName.isEmpty()) {
-                String paramName = parser.getAttributeValue(null, Attribute.NAME.toString());
-                String paramValue = parser.getAttributeValue(null, Attribute.VALUE.toString());
+                String paramName = parser.getAttributeValue(null, SinkEventAttributes.NAME);
+                String paramValue = parser.getAttributeValue(null, SinkEventAttributes.VALUE);
 
                 if ((paramName == null || paramName.isEmpty()) || (paramValue == null || paramValue.isEmpty())) {
                     throw new MacroExecutionException(
-                            "'" + Attribute.NAME.toString() + "' and '" + Attribute.VALUE.toString()
+                            "'" + SinkEventAttributes.NAME + "' and '" + SinkEventAttributes.VALUE
                                     + "' attributes for the '" + PARAM.toString() + "' tag are required inside the '"
                                     + MACRO_TAG.toString() + "' tag.");
                 }
@@ -343,7 +343,7 @@ public class XdocParser extends Xhtml1BaseParser implements XdocMarkup {
     private void handleSectionStart(int level, Sink sink, SinkEventAttributeSet attribs, XmlPullParser parser) {
         consecutiveSections(level, sink);
 
-        Object id = attribs.getAttribute(Attribute.ID.toString());
+        Object id = attribs.getAttribute(SinkEventAttributes.ID);
 
         if (id != null) {
             sink.anchor(id.toString());
@@ -352,7 +352,7 @@ public class XdocParser extends Xhtml1BaseParser implements XdocMarkup {
 
         sink.section(level, attribs);
         sink.sectionTitle(level, null);
-        sink.text(HtmlTools.unescapeHTML(parser.getAttributeValue(null, Attribute.NAME.toString())));
+        sink.text(HtmlTools.unescapeHTML(parser.getAttributeValue(null, SinkEventAttributes.NAME)));
         sink.sectionTitle_(level);
     }
 

--- a/doxia-modules/doxia-module-xdoc/src/main/java/org/apache/maven/doxia/module/xdoc/XdocSink.java
+++ b/doxia-modules/doxia-module-xdoc/src/main/java/org/apache/maven/doxia/module/xdoc/XdocSink.java
@@ -19,7 +19,6 @@
 package org.apache.maven.doxia.module.xdoc;
 
 import javax.swing.text.MutableAttributeSet;
-import javax.swing.text.html.HTML.Attribute;
 
 import java.io.Writer;
 
@@ -124,7 +123,7 @@ public class XdocSink extends Xhtml5BaseSink implements XdocMarkup {
         atts.addAttribute("xsi:schemaLocation", XDOC_NAMESPACE + " " + XDOC_SYSTEM_ID);
 
         if (languageId != null) {
-            atts.addAttribute(Attribute.LANG.toString(), languageId);
+            atts.addAttribute(SinkEventAttributes.LANG, languageId);
             atts.addAttribute("xml:lang", languageId);
         }
 
@@ -246,7 +245,7 @@ public class XdocSink extends Xhtml5BaseSink implements XdocMarkup {
                     + SinkUtils.getAttributeString(
                             SinkUtils.filterAttributes(attributes, SinkUtils.SINK_BASE_ATTRIBUTES))
                     + SPACE
-                    + Attribute.NAME
+                    + SinkEventAttributes.NAME
                     + EQUAL
                     + QUOTE);
         } else if (depth == SECTION_LEVEL_2) {
@@ -255,7 +254,7 @@ public class XdocSink extends Xhtml5BaseSink implements XdocMarkup {
                     + SinkUtils.getAttributeString(
                             SinkUtils.filterAttributes(attributes, SinkUtils.SINK_BASE_ATTRIBUTES))
                     + SPACE
-                    + Attribute.NAME
+                    + SinkEventAttributes.NAME
                     + EQUAL
                     + QUOTE);
         }
@@ -385,8 +384,8 @@ public class XdocSink extends Xhtml5BaseSink implements XdocMarkup {
 
         MutableAttributeSet att = new SinkEventAttributeSet();
 
-        if (!tableAttributes.isDefined(Attribute.BORDER.toString())) {
-            att.addAttribute(Attribute.BORDER, (grid ? "1" : "0"));
+        if (!tableAttributes.isDefined(SinkEventAttributes.BORDER)) {
+            att.addAttribute(SinkEventAttributes.BORDER, (grid ? "1" : "0"));
         }
 
         att.addAttributes(tableAttributes);

--- a/doxia-modules/doxia-module-xdoc/src/test/java/org/apache/maven/doxia/module/xdoc/XdocSinkTest.java
+++ b/doxia-modules/doxia-module-xdoc/src/test/java/org/apache/maven/doxia/module/xdoc/XdocSinkTest.java
@@ -18,8 +18,6 @@
  */
 package org.apache.maven.doxia.module.xdoc;
 
-import javax.swing.text.html.HTML.Attribute;
-
 import java.io.StringWriter;
 import java.io.Writer;
 
@@ -311,7 +309,7 @@ public class XdocSinkTest extends AbstractSinkTest {
             sink.link("name");
             sink.link_();
             SinkEventAttributes attrs = new SinkEventAttributeSet();
-            attrs.addAttribute(Attribute.TARGET, "nirvana");
+            attrs.addAttribute(SinkEventAttributes.TARGET, "nirvana");
             sink.link("name", attrs);
             sink.link_();
         }

--- a/doxia-modules/doxia-module-xhtml5/src/main/java/org/apache/maven/doxia/module/xhtml5/Xhtml5Parser.java
+++ b/doxia-modules/doxia-module-xhtml5/src/main/java/org/apache/maven/doxia/module/xhtml5/Xhtml5Parser.java
@@ -20,7 +20,6 @@ package org.apache.maven.doxia.module.xhtml5;
 
 import javax.inject.Named;
 import javax.inject.Singleton;
-import javax.swing.text.html.HTML.Attribute;
 
 import java.io.IOException;
 import java.io.Reader;
@@ -37,6 +36,7 @@ import org.apache.maven.doxia.parser.ParseException;
 import org.apache.maven.doxia.parser.Xhtml5BaseParser;
 import org.apache.maven.doxia.sink.Sink;
 import org.apache.maven.doxia.sink.SinkEventAttributeSet;
+import org.apache.maven.doxia.sink.SinkEventAttributes;
 import org.apache.maven.doxia.util.DoxiaStringUtils;
 import org.codehaus.plexus.util.xml.pull.XmlPullParser;
 import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
@@ -76,8 +76,8 @@ public class Xhtml5Parser extends Xhtml5BaseParser implements Xhtml5Markup {
         } else if (parser.getName().equals(TITLE.toString())) {
             sink.title(attribs);
         } else if (parser.getName().equals(META.toString())) {
-            String name = parser.getAttributeValue(null, Attribute.NAME.toString());
-            String content = parser.getAttributeValue(null, Attribute.CONTENT.toString());
+            String name = parser.getAttributeValue(null, SinkEventAttributes.NAME);
+            String content = parser.getAttributeValue(null, SinkEventAttributes.CONTENT);
 
             if ("author".equals(name)) {
                 sink.author(null);
@@ -105,7 +105,7 @@ public class Xhtml5Parser extends Xhtml5BaseParser implements Xhtml5Markup {
         } else if (parser.getName().equals(BODY.toString())) {
             sink.body(attribs);
         } else if (parser.getName().equals(DIV.toString())) {
-            String divClass = parser.getAttributeValue(null, Attribute.CLASS.toString());
+            String divClass = parser.getAttributeValue(null, SinkEventAttributes.CLASS);
 
             if ("verbatim source".equals(divClass)) {
                 this.source = true;

--- a/doxia-modules/doxia-module-xhtml5/src/main/java/org/apache/maven/doxia/module/xhtml5/Xhtml5Sink.java
+++ b/doxia-modules/doxia-module-xhtml5/src/main/java/org/apache/maven/doxia/module/xhtml5/Xhtml5Sink.java
@@ -19,7 +19,6 @@
 package org.apache.maven.doxia.module.xhtml5;
 
 import javax.swing.text.MutableAttributeSet;
-import javax.swing.text.html.HTML.Attribute;
 
 import java.io.Writer;
 
@@ -101,7 +100,7 @@ public class Xhtml5Sink extends Xhtml5BaseSink implements Xhtml5Markup {
         atts.addAttribute("xmlns", XHTML5_NAMESPACE);
 
         if (languageId != null) {
-            atts.addAttribute(Attribute.LANG.toString(), languageId);
+            atts.addAttribute(SinkEventAttributes.LANG, languageId);
             atts.addAttribute("xml:lang", languageId);
         }
 
@@ -166,12 +165,12 @@ public class Xhtml5Sink extends Xhtml5BaseSink implements Xhtml5Markup {
     public void author_() {
         if (getTextBuffer().length() > 0) {
             MutableAttributeSet att = new SinkEventAttributeSet();
-            att.addAttribute(Attribute.NAME, "author");
+            att.addAttribute(SinkEventAttributes.NAME, "author");
             String text = HtmlTools.escapeHTML(getTextBuffer().toString());
             // hack: un-escape numerical entities that have been escaped above
             // note that numerical entities should really be added as one unicode character in the first place
             text = DoxiaStringUtils.replace(text, "&amp;#", "&#");
-            att.addAttribute(Attribute.CONTENT, text);
+            att.addAttribute(SinkEventAttributes.CONTENT, text);
 
             writeSimpleTag(META, att);
 
@@ -187,8 +186,8 @@ public class Xhtml5Sink extends Xhtml5BaseSink implements Xhtml5Markup {
     public void date_() {
         if (getTextBuffer().length() > 0) {
             MutableAttributeSet att = new SinkEventAttributeSet();
-            att.addAttribute(Attribute.NAME, "date");
-            att.addAttribute(Attribute.CONTENT, getTextBuffer().toString());
+            att.addAttribute(SinkEventAttributes.NAME, "date");
+            att.addAttribute(SinkEventAttributes.CONTENT, getTextBuffer().toString());
 
             writeSimpleTag(META, att);
 

--- a/doxia-sink-api/src/main/java/org/apache/maven/doxia/sink/SinkEventAttributeSet.java
+++ b/doxia-sink-api/src/main/java/org/apache/maven/doxia/sink/SinkEventAttributeSet.java
@@ -375,13 +375,12 @@ public class SinkEventAttributeSet implements SinkEventAttributes, Cloneable {
     @Override
     public String toString() {
         StringBuilder s = new StringBuilder();
-        Enumeration<String> names = getAttributeNames();
 
-        while (names.hasMoreElements()) {
-            String key = names.nextElement();
-            String value = getAttribute(key).toString();
-
-            s.append(' ').append(key).append('=').append(value);
+        for (Map.Entry<String, Object> attribute : entrySet()) {
+            s.append(' ')
+                    .append(attribute.getKey())
+                    .append('=')
+                    .append(attribute.getValue().toString());
         }
 
         return s.toString();

--- a/doxia-sink-api/src/main/java/org/apache/maven/doxia/sink/SinkEventAttributes.java
+++ b/doxia-sink-api/src/main/java/org/apache/maven/doxia/sink/SinkEventAttributes.java
@@ -112,6 +112,13 @@ public interface SinkEventAttributes extends MutableAttributeSet {
      */
     String EMAIL = "email";
 
+    /**
+     * The value of a meta element, used together with {@link #NAME}.
+     *
+     * @since 2.2.0
+     */
+    String CONTENT = "content";
+
     // img
 
     /**


### PR DESCRIPTION
Phases 1 and 2 of #1092, in two commits so each stands on its own.

**`HTML.Attribute` is gone from every main source.** All 42 uses were `Attribute.X.toString()` —
a constant table that cost doxia-core and three modules a `java.desktop` dependency. The eleven
names in use match their `SinkEventAttributes` constant exactly; I checked that by running
`HTML.Attribute` against the literals rather than reading them off, so no generated output moves.
The sink tests that assert exact HTML (`Xhtml5SinkTest`, `XdocSinkTest`, `MarkdownSinkTest`) pass
unchanged, which is the real evidence.

Five of those uses passed the `Attribute` object itself as an attribute key, in `XdocSink` and
`Xhtml5Sink`. They worked only because `addAttribute` calls `name.toString()` on the key while
`getAttribute`, `isDefined` and `removeAttribute` do not — so such an entry could only ever be read
back with a `String`. All keys are `String` now.

`SinkEventAttributes` gains `CONTENT`, the one name in use it lacked.

**Phase 2 is smaller than #1092 claims, and that is my error in the issue.** It says to move
`SinkUtils.getAttributeString`, `asCssString` and `filterAttributes` onto `entrySet()`. That is not
possible in 2.x: all three take `javax.swing.text.AttributeSet`, which has no `entrySet()`, and
widening those parameters is a binary break. The same applies to
`Xhtml5BaseSink.writeStartTag(Tag, MutableAttributeSet, boolean)` and to the `SinkEventAttributeSet`
methods that implement the Swing interface. Only two sites were free, both already holding a
`SinkEventAttributes`. The rest waits on phase 4.

What is left of javax.swing after this: `HTML.Tag` (phase 3) and `AttributeSet`/`MutableAttributeSet`
(phase 4).

Verified: `mvn verify` green — japicmp on both published modules, RAT and checkstyle across all ten,
every test passing.

Part of #1092

*This change was created with AI assistance.*
