### PR TITLE
Deprecate LineBreaker and take commons-io off the compile classpath

### DIFF
--- a/doxia-core/pom.xml
+++ b/doxia-core/pom.xml
@@ -47,12 +47,13 @@ under the License.
       <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-xml</artifactId>
     </dependency>
+
+    <!-- test -->
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
+      <scope>test</scope>
     </dependency>
-
-    <!-- test -->
     <dependency>
       <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-testing</artifactId>

--- a/doxia-core/src/main/java/org/apache/maven/doxia/parser/AbstractXmlParser.java
+++ b/doxia-core/src/main/java/org/apache/maven/doxia/parser/AbstractXmlParser.java
@@ -20,10 +20,12 @@ package org.apache.maven.doxia.parser;
 
 import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.Reader;
 import java.io.StringReader;
+import java.io.StringWriter;
 import java.net.URI;
 import java.net.URL;
 import java.nio.file.Paths;
@@ -34,7 +36,6 @@ import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.apache.commons.io.IOUtils;
 import org.apache.maven.doxia.macro.MacroExecutionException;
 import org.apache.maven.doxia.markup.XmlMarkup;
 import org.apache.maven.doxia.sink.Sink;
@@ -109,7 +110,13 @@ public abstract class AbstractXmlParser extends AbstractParser implements XmlMar
         if (isValidate()) {
             String content;
             try {
-                content = IOUtils.toString(new BufferedReader(src));
+                StringWriter contentWriter = new StringWriter();
+                char[] buffer = new char[8192];
+                int n;
+                while ((n = src.read(buffer)) != -1) {
+                    contentWriter.write(buffer, 0, n);
+                }
+                content = contentWriter.toString();
             } catch (IOException e) {
                 throw new ParseException("Error reading the model", e);
             }
@@ -717,7 +724,13 @@ public abstract class AbstractXmlParser extends AbstractParser implements XmlMar
                 if (is == null) {
                     throw new SAXException("Cannot open stream from the url: " + url);
                 }
-                return IOUtils.toByteArray(is);
+                ByteArrayOutputStream out = new ByteArrayOutputStream();
+                byte[] buffer = new byte[8192];
+                int n;
+                while ((n = is.read(buffer)) != -1) {
+                    out.write(buffer, 0, n);
+                }
+                return out.toByteArray();
             } catch (IOException e) {
                 throw new SAXException(e);
             }

--- a/doxia-core/src/main/java/org/apache/maven/doxia/util/LineBreaker.java
+++ b/doxia-core/src/main/java/org/apache/maven/doxia/util/LineBreaker.java
@@ -24,7 +24,11 @@ import java.io.Writer;
 
 /**
  * Allows to specify the line-length of an output writer.
+ *
+ * @deprecated no longer used by Doxia and scheduled for removal in 2.3.0. It also swallows every
+ * write failure, so a failing writer would produce a silently truncated file.
  */
+@Deprecated
 public class LineBreaker {
     /** The default maximal line length. */
     public static final int DEFAULT_MAX_LINE_LENGTH = 78;

--- a/doxia-modules/doxia-module-apt/pom.xml
+++ b/doxia-modules/doxia-module-apt/pom.xml
@@ -38,10 +38,6 @@ under the License.
       <artifactId>slf4j-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>commons-io</groupId>
-      <artifactId>commons-io</artifactId>
-    </dependency>
-    <dependency>
       <groupId>javax.inject</groupId>
       <artifactId>javax.inject</artifactId>
     </dependency>

--- a/doxia-modules/doxia-module-apt/src/main/java/org/apache/maven/doxia/module/apt/AptParser.java
+++ b/doxia-modules/doxia-module-apt/src/main/java/org/apache/maven/doxia/module/apt/AptParser.java
@@ -29,7 +29,6 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.StringTokenizer;
 
-import org.apache.commons.io.IOUtils;
 import org.apache.maven.doxia.macro.MacroExecutionException;
 import org.apache.maven.doxia.macro.MacroRequest;
 import org.apache.maven.doxia.macro.manager.MacroNotFoundException;
@@ -208,7 +207,11 @@ public class AptParser extends AbstractTextParser implements AptMarkup {
 
         try {
             StringWriter contentWriter = new StringWriter();
-            IOUtils.copy(source, contentWriter);
+            char[] buffer = new char[8192];
+            int n;
+            while ((n = source.read(buffer)) != -1) {
+                contentWriter.write(buffer, 0, n);
+            }
             sourceContent = contentWriter.toString();
         } catch (IOException e) {
             throw new AptParseException(e);

--- a/doxia-modules/doxia-module-fml/pom.xml
+++ b/doxia-modules/doxia-module-fml/pom.xml
@@ -45,12 +45,13 @@ under the License.
       <groupId>javax.inject</groupId>
       <artifactId>javax.inject</artifactId>
     </dependency>
+
+    <!-- test -->
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
+      <scope>test</scope>
     </dependency>
-
-    <!-- test -->
     <dependency>
       <groupId>org.apache.maven.doxia</groupId>
       <artifactId>doxia-test-docs</artifactId>

--- a/doxia-modules/doxia-module-fml/src/main/java/org/apache/maven/doxia/module/fml/FmlParser.java
+++ b/doxia-modules/doxia-module-fml/src/main/java/org/apache/maven/doxia/module/fml/FmlParser.java
@@ -31,7 +31,6 @@ import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
-import org.apache.commons.io.IOUtils;
 import org.apache.maven.doxia.macro.MacroExecutionException;
 import org.apache.maven.doxia.macro.MacroRequest;
 import org.apache.maven.doxia.macro.manager.MacroNotFoundException;
@@ -91,7 +90,11 @@ public class FmlParser extends AbstractXmlParser implements FmlMarkup {
 
         try (Reader reader = source) {
             StringWriter contentWriter = new StringWriter();
-            IOUtils.copy(reader, contentWriter);
+            char[] buffer = new char[8192];
+            int n;
+            while ((n = reader.read(buffer)) != -1) {
+                contentWriter.write(buffer, 0, n);
+            }
             sourceContent = contentWriter.toString();
         } catch (IOException ex) {
             throw new ParseException("Error reading the input source", ex);

--- a/doxia-modules/doxia-module-markdown/pom.xml
+++ b/doxia-modules/doxia-module-markdown/pom.xml
@@ -59,6 +59,7 @@ under the License.
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
+      <scope>test</scope>
     </dependency>
 
     <dependency>

--- a/doxia-modules/doxia-module-markdown/src/main/java/org/apache/maven/doxia/module/markdown/MarkdownParser.java
+++ b/doxia-modules/doxia-module-markdown/src/main/java/org/apache/maven/doxia/module/markdown/MarkdownParser.java
@@ -50,7 +50,6 @@ import com.vladsch.flexmark.html.HtmlRenderer;
 import com.vladsch.flexmark.util.ast.Node;
 import com.vladsch.flexmark.util.ast.TextCollectingVisitor;
 import com.vladsch.flexmark.util.data.MutableDataSet;
-import org.apache.commons.io.IOUtils;
 import org.apache.maven.doxia.markup.HtmlMarkup;
 import org.apache.maven.doxia.markup.TextMarkup;
 import org.apache.maven.doxia.module.xhtml5.Xhtml5Parser;
@@ -284,7 +283,12 @@ public class MarkdownParser extends AbstractTextParser implements TextMarkup {
      */
     String toXhtml(Reader source) throws IOException {
         // Read the source
-        StringBuilder markdownText = new StringBuilder(IOUtils.toString(source));
+        StringBuilder markdownText = new StringBuilder();
+        char[] buffer = new char[8192];
+        int n;
+        while ((n = source.read(buffer)) != -1) {
+            markdownText.append(buffer, 0, n);
+        }
 
         // Now, build the HTML document
         StringBuilder html = new StringBuilder(1000);

--- a/doxia-modules/doxia-module-xdoc/pom.xml
+++ b/doxia-modules/doxia-module-xdoc/pom.xml
@@ -42,15 +42,16 @@ under the License.
       <artifactId>javax.inject</artifactId>
     </dependency>
     <dependency>
-      <groupId>commons-io</groupId>
-      <artifactId>commons-io</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-xml</artifactId>
     </dependency>
 
     <!-- test -->
+    <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+      <scope>test</scope>
+    </dependency>
     <dependency>
       <groupId>org.apache.maven.doxia</groupId>
       <artifactId>doxia-test-docs</artifactId>

--- a/doxia-modules/doxia-module-xdoc/src/main/java/org/apache/maven/doxia/module/xdoc/XdocParser.java
+++ b/doxia-modules/doxia-module-xdoc/src/main/java/org/apache/maven/doxia/module/xdoc/XdocParser.java
@@ -30,7 +30,6 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
-import org.apache.commons.io.IOUtils;
 import org.apache.maven.doxia.macro.MacroExecutionException;
 import org.apache.maven.doxia.macro.MacroRequest;
 import org.apache.maven.doxia.macro.manager.MacroNotFoundException;
@@ -90,7 +89,11 @@ public class XdocParser extends Xhtml1BaseParser implements XdocMarkup {
 
         try (Reader reader = source) {
             StringWriter contentWriter = new StringWriter();
-            IOUtils.copy(reader, contentWriter);
+            char[] buffer = new char[8192];
+            int n;
+            while ((n = reader.read(buffer)) != -1) {
+                contentWriter.write(buffer, 0, n);
+            }
             sourceContent = contentWriter.toString();
         } catch (IOException ex) {
             throw new ParseException("Error reading the input source", ex);

--- a/doxia-modules/doxia-module-xhtml5/pom.xml
+++ b/doxia-modules/doxia-module-xhtml5/pom.xml
@@ -42,10 +42,6 @@ under the License.
       <artifactId>javax.inject</artifactId>
     </dependency>
     <dependency>
-      <groupId>commons-io</groupId>
-      <artifactId>commons-io</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-xml</artifactId>
     </dependency>

--- a/doxia-modules/doxia-module-xhtml5/src/main/java/org/apache/maven/doxia/module/xhtml5/Xhtml5Parser.java
+++ b/doxia-modules/doxia-module-xhtml5/src/main/java/org/apache/maven/doxia/module/xhtml5/Xhtml5Parser.java
@@ -29,7 +29,6 @@ import java.io.StringWriter;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
-import org.apache.commons.io.IOUtils;
 import org.apache.maven.doxia.macro.MacroExecutionException;
 import org.apache.maven.doxia.macro.MacroRequest;
 import org.apache.maven.doxia.macro.manager.MacroNotFoundException;
@@ -269,7 +268,11 @@ public class Xhtml5Parser extends Xhtml5BaseParser implements Xhtml5Markup {
 
         try (Reader reader = source) {
             StringWriter contentWriter = new StringWriter();
-            IOUtils.copy(reader, contentWriter);
+            char[] buffer = new char[8192];
+            int n;
+            while ((n = reader.read(buffer)) != -1) {
+                contentWriter.write(buffer, 0, n);
+            }
             sourceContent = contentWriter.toString();
         } catch (IOException ex) {
             throw new ParseException("Error reading the input source", ex);


### PR DESCRIPTION
Closes #1093. Two independent commits: `LineBreaker` is deprecated for removal in 2.3.0 rather than deleted, since it is public API of a released module; the seven `IOUtils` call sites become copy loops, which moves commons-io to test scope in doxia-core, fml, markdown and xdoc and off apt and xhtml5 entirely.

Verified: `mvn install` → BUILD SUCCESS, all module test suites green, japicmp clean on doxia-sink-api and doxia-core.

*This change was created with AI assistance.*